### PR TITLE
Add end-to-end API tests using pytest and requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,18 @@ This is the backend service for a diet and fitness application i made with a fri
 - Python 3.x installed (for local development)
 
 
+
+## Running Tests
+
+1. Install application dependencies:
+   ```bash
+   pip install -r api/requirements.txt
+   ```
+2. Install test dependencies:
+   ```bash
+   pip install -r requirements-dev.txt
+   ```
+3. Run the automated test suite:
+   ```bash
+   pytest
+   ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = api

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==7.4.4
+requests==2.31.0

--- a/tests/_requests_stub.py
+++ b/tests/_requests_stub.py
@@ -1,0 +1,70 @@
+"""Minimal fallback implementation of a subset of the requests API for offline testing."""
+
+from __future__ import annotations
+
+import json as json_module
+from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+
+class ConnectionError(Exception):
+    """Simplified connection error used to mimic requests.exceptions.ConnectionError."""
+
+
+def _prepare_url(url: str, params: dict | None) -> str:
+    if not params:
+        return url
+    parsed = urlparse(url)
+    query = urlencode(params, doseq=True)
+    new_query = f"{parsed.query}&{query}" if parsed.query else query
+    return urlunparse(parsed._replace(query=new_query))
+
+
+class Response:
+    def __init__(self, status_code: int, headers, body: bytes):
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    @property
+    def text(self) -> str:
+        return self._body.decode("utf-8")
+
+    def json(self):
+        return json_module.loads(self._body.decode("utf-8"))
+
+
+def _request(method: str, url: str, *, params=None, json=None):
+    target = _prepare_url(url, params)
+    data = None
+    headers = {}
+    if json is not None:
+        data = json_module.dumps(json).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = Request(target, data=data, method=method.upper())
+    for key, value in headers.items():
+        request.add_header(key, value)
+    try:
+        with urlopen(request) as response:  # nosec B310 - only used in tests
+            body = response.read()
+            return Response(response.status, response.headers, body)
+    except HTTPError as exc:  # pragma: no cover - error path is exercised in tests
+        body = exc.read() or b""
+        return Response(exc.code, exc.headers, body)
+    except URLError as exc:  # pragma: no cover - connection failures are rare
+        raise ConnectionError(str(exc)) from exc
+
+
+def get(url: str, params=None):
+    return _request("GET", url, params=params)
+
+
+def post(url: str, json=None):
+    return _request("POST", url, json=json)
+
+
+exceptions = SimpleNamespace(ConnectionError=ConnectionError)
+
+__all__ = ["get", "post", "exceptions", "Response", "ConnectionError"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import time
+import threading
+from pathlib import Path
+
+import pytest
+try:  # pragma: no cover - exercised when requests is installed
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - offline fallback
+    from . import _requests_stub as requests
+from werkzeug.serving import make_server
+
+
+@pytest.fixture(scope="session")
+def app_environment(tmp_path_factory):
+    project_root = Path(__file__).resolve().parents[1]
+    api_dir = project_root / "api"
+    if str(api_dir) not in sys.path:
+        sys.path.insert(0, str(api_dir))
+
+    db_path = tmp_path_factory.mktemp("db") / "test.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    from app import app
+    from models import Base
+    from database import engine
+
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    server = make_server("127.0.0.1", 0, app)
+    port = server.server_port
+
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+
+    timeout = time.time() + 5
+    while time.time() < timeout:
+        try:
+            requests.get(f"{base_url}/")
+            break
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.05)
+    else:
+        server.shutdown()
+        thread.join(timeout=1)
+        raise RuntimeError("Flask test server did not start in time")
+
+    try:
+        yield {
+            "base_url": base_url,
+            "Base": Base,
+            "engine": engine,
+        }
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+@pytest.fixture(autouse=True)
+def reset_database(app_environment):
+    Base = app_environment["Base"]
+    engine = app_environment["engine"]
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture
+def base_url(app_environment):
+    return app_environment["base_url"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,188 @@
+import time
+from datetime import datetime, timedelta
+
+try:  # pragma: no cover - exercised when requests is available
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - offline fallback
+    from . import _requests_stub as requests
+
+
+def create_user(base_url, username, email, **extra):
+    payload = {
+        "username": username,
+        "email": email,
+        "password": "strongpassword",
+        "full_name": extra.get("full_name", "Test User"),
+        "gender": extra.get("gender", "non-binary"),
+        "age": extra.get("age", 30),
+        "weight": extra.get("weight", 70.5),
+        "height": extra.get("height", 175.0),
+        "goal": extra.get("goal", "Maintain weight"),
+    }
+    response = requests.post(f"{base_url}/users", json=payload)
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert "user_id" in data
+    return data["user_id"]
+
+
+def test_index_page_loads(base_url):
+    response = requests.get(f"{base_url}/")
+    assert response.status_code == 200
+    assert "Welcome to the Diet Appointments Dashboard" in response.text
+
+
+def test_user_creation_and_listing(base_url):
+    username = "integration_user"
+    email = "integration@example.com"
+    response = requests.post(
+        f"{base_url}/users",
+        json={
+            "username": username,
+            "email": email,
+            "password": "anotherpassword",
+            "full_name": "Integration Tester",
+            "gender": "female",
+            "age": 28,
+            "weight": 62.3,
+            "height": 168.2,
+            "goal": "Build muscle",
+            "neck_circumference": 34.1,
+            "abdomen_circumference": 72.4,
+            "hip_circumference": 95.0,
+            "underlying_medical_conditions": "None",
+        },
+    )
+    assert response.status_code == 201
+    user_id = response.json()["user_id"]
+    assert user_id > 0
+
+    list_response = requests.get(f"{base_url}/users")
+    assert list_response.status_code == 200
+    users = list_response.json()
+    assert len(users) == 1
+    user = users[0]
+    assert user["username"] == username
+    assert user["email"] == email
+    assert user["goal"] == "Build muscle"
+    assert user["weight"] == 62.3
+    assert user["height"] == 168.2
+
+
+def test_user_creation_requires_password(base_url):
+    response = requests.post(
+        f"{base_url}/users",
+        json={
+            "username": "no_password_user",
+            "email": "nopassword@example.com",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Password is required"
+
+
+def test_diet_plan_creation_and_retrieval(base_url):
+    user_id = create_user(base_url, "dietuser", "diet@example.com")
+
+    start_date = datetime.utcnow().date()
+    end_date = start_date + timedelta(days=30)
+    response = requests.post(
+        f"{base_url}/users/{user_id}/diet_plans",
+        json={
+            "nutritionist_id": 42,
+            "start_date": start_date.strftime("%Y-%m-%d"),
+            "end_date": end_date.strftime("%Y-%m-%d"),
+            "meal_details": "High protein diet",
+            "preferences_client_notes": "No peanuts",
+            "notes": "Follow-up in two weeks",
+        },
+    )
+    assert response.status_code == 201
+    diet_id = response.json()["diet_id"]
+    assert diet_id > 0
+
+    list_response = requests.get(f"{base_url}/users/{user_id}/diet_plans")
+    assert list_response.status_code == 200
+    diet_plans = list_response.json()
+    assert len(diet_plans) == 1
+    plan = diet_plans[0]
+    assert plan["diet_id"] == diet_id
+    assert plan["meal_details"] == "High protein diet"
+    assert plan["preferences_client_notes"] == "No peanuts"
+    assert plan["start_date"].startswith(start_date.isoformat())
+    assert plan["end_date"].startswith(end_date.isoformat())
+
+
+def test_message_conversation_flow(base_url):
+    sender_id = create_user(base_url, "sender", "sender@example.com")
+    receiver_id = create_user(base_url, "receiver", "receiver@example.com")
+
+    first_message = {
+        "sender_id": sender_id,
+        "receiver_id": receiver_id,
+        "message_content": "Hello there!",
+    }
+    response = requests.post(f"{base_url}/messages", json=first_message)
+    assert response.status_code == 201
+
+    time.sleep(0.05)
+
+    second_message = {
+        "sender_id": receiver_id,
+        "receiver_id": sender_id,
+        "message_content": "Hi! Great to hear from you.",
+    }
+    response = requests.post(f"{base_url}/messages", json=second_message)
+    assert response.status_code == 201
+
+    conversation = requests.get(
+        f"{base_url}/messages/conversation",
+        params={"user1_id": sender_id, "user2_id": receiver_id},
+    )
+    assert conversation.status_code == 200
+    messages = conversation.json()
+    assert [m["message_content"] for m in messages] == [
+        "Hello there!",
+        "Hi! Great to hear from you.",
+    ]
+    assert messages[0]["sender_id"] == sender_id
+    assert messages[1]["sender_id"] == receiver_id
+
+
+def test_appointment_workflow(base_url):
+    client_id = create_user(base_url, "client", "client@example.com")
+    nutritionist_id = create_user(base_url, "nutritionist", "nutritionist@example.com")
+
+    scheduled_at = datetime.utcnow().replace(microsecond=0)
+    response = requests.post(
+        f"{base_url}/appointments",
+        json={
+            "client_id": client_id,
+            "nutritionist_id": nutritionist_id,
+            "scheduled_at": scheduled_at.strftime("%Y-%m-%d %H:%M:%S"),
+            "status": "confirmed",
+            "google_calendar_event_id": "event123",
+        },
+    )
+    assert response.status_code == 201
+    appointment_id = response.json()["appointment_id"]
+
+    detail_response = requests.get(f"{base_url}/appointments/{appointment_id}")
+    assert detail_response.status_code == 200
+    appointment = detail_response.json()
+    assert appointment["appointment_id"] == appointment_id
+    assert appointment["client_id"] == client_id
+    assert appointment["nutritionist_id"] == nutritionist_id
+    assert appointment["status"] == "confirmed"
+    assert appointment["google_calendar_event_id"] == "event123"
+    assert appointment["scheduled_at"].startswith(scheduled_at.isoformat())
+
+    list_response = requests.get(f"{base_url}/appointments")
+    assert list_response.status_code == 200
+    appointments = list_response.json()
+    assert len(appointments) == 1
+    assert appointments[0]["appointment_id"] == appointment_id
+
+    not_found = requests.get(f"{base_url}/appointments/{appointment_id + 1}")
+    assert not_found.status_code == 404
+    assert not_found.json()["message"] == "Appointment not found"


### PR DESCRIPTION
## Summary
- configure pytest to import the API package and add dev requirements for test tooling
- add integration-style tests that exercise the Flask routes via HTTP requests, including diet plans, messages, and appointments
- document how to install dependencies and run the automated test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dba75cc6908322a68a54f4e824f8cc