### PR TITLE
Enhance API validation and expand route coverage

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -95,20 +95,28 @@ def get_diet_plans(user_id):
 def create_diet_plan(user_id):
     data = request.get_json()
     session = SessionLocal()
-    new_diet_plan = DietPlan(
-        user_id=user_id,
-        nutritionist_id=data.get('nutritionist_id'),
-        start_date=datetime.strptime(data['start_date'], '%Y-%m-%d'),
-        end_date=datetime.strptime(data['end_date'], '%Y-%m-%d'),
-        meal_details=data['meal_details'],
-        preferences_client_notes=data.get('preferences_client_notes'),
-        notes=data.get('notes')
-    )
-    session.add(new_diet_plan)
-    session.commit()
-    session.refresh(new_diet_plan)
-    session.close()
-    return jsonify({"message": "Diet plan created successfully", "diet_id": new_diet_plan.diet_id}), 201
+    try:
+        try:
+            start_date = datetime.strptime(data['start_date'], '%Y-%m-%d')
+            end_date = datetime.strptime(data['end_date'], '%Y-%m-%d')
+        except (KeyError, TypeError, ValueError):
+            return jsonify({"error": "Invalid date format. Expected YYYY-MM-DD."}), 400
+
+        new_diet_plan = DietPlan(
+            user_id=user_id,
+            nutritionist_id=data.get('nutritionist_id'),
+            start_date=start_date,
+            end_date=end_date,
+            meal_details=data['meal_details'],
+            preferences_client_notes=data.get('preferences_client_notes'),
+            notes=data.get('notes')
+        )
+        session.add(new_diet_plan)
+        session.commit()
+        session.refresh(new_diet_plan)
+        return jsonify({"message": "Diet plan created successfully", "diet_id": new_diet_plan.diet_id}), 201
+    finally:
+        session.close()
 
 # --------------------------------
 # Messages Endpoints
@@ -157,18 +165,25 @@ def get_conversation():
 def create_appointment():
     data = request.get_json()
     session = SessionLocal()
-    new_appointment = Appointment(
-        client_id=data['client_id'],
-        nutritionist_id=data['nutritionist_id'],
-        scheduled_at=datetime.strptime(data['scheduled_at'], '%Y-%m-%d %H:%M:%S'),
-        status=data.get('status', 'scheduled'),
-        google_calendar_event_id=data.get('google_calendar_event_id')
-    )
-    session.add(new_appointment)
-    session.commit()
-    session.refresh(new_appointment)
-    session.close()
-    return jsonify({"message": "Appointment created successfully", "appointment_id": new_appointment.appointment_id}), 201
+    try:
+        try:
+            scheduled_at = datetime.strptime(data['scheduled_at'], '%Y-%m-%d %H:%M:%S')
+        except (KeyError, TypeError, ValueError):
+            return jsonify({"error": "Invalid datetime format. Expected YYYY-MM-DD HH:MM:SS."}), 400
+
+        new_appointment = Appointment(
+            client_id=data['client_id'],
+            nutritionist_id=data['nutritionist_id'],
+            scheduled_at=scheduled_at,
+            status=data.get('status', 'scheduled'),
+            google_calendar_event_id=data.get('google_calendar_event_id')
+        )
+        session.add(new_appointment)
+        session.commit()
+        session.refresh(new_appointment)
+        return jsonify({"message": "Appointment created successfully", "appointment_id": new_appointment.appointment_id}), 201
+    finally:
+        session.close()
 
 @bp.route('/appointments/<int:appointment_id>', methods=['GET'])
 def get_appointment(appointment_id):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,8 @@
 import time
 from datetime import datetime, timedelta
 
+from werkzeug.security import generate_password_hash
+
 try:  # pragma: no cover - exercised when requests is available
     import requests  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - offline fallback
@@ -81,6 +83,22 @@ def test_user_creation_requires_password(base_url):
     assert response.json()["error"] == "Password is required"
 
 
+def test_user_creation_accepts_prehashed_password(base_url):
+    hashed_password = generate_password_hash("already_secure")
+    response = requests.post(
+        f"{base_url}/users",
+        json={
+            "username": "prehashed",
+            "email": "prehashed@example.com",
+            "password_hash": hashed_password,
+        },
+    )
+    assert response.status_code == 201
+
+    users = requests.get(f"{base_url}/users").json()
+    assert users[0]["username"] == "prehashed"
+
+
 def test_diet_plan_creation_and_retrieval(base_url):
     user_id = create_user(base_url, "dietuser", "diet@example.com")
 
@@ -111,6 +129,21 @@ def test_diet_plan_creation_and_retrieval(base_url):
     assert plan["preferences_client_notes"] == "No peanuts"
     assert plan["start_date"].startswith(start_date.isoformat())
     assert plan["end_date"].startswith(end_date.isoformat())
+
+
+def test_diet_plan_creation_with_invalid_dates_returns_400(base_url):
+    user_id = create_user(base_url, "dietuser2", "diet2@example.com")
+    response = requests.post(
+        f"{base_url}/users/{user_id}/diet_plans",
+        json={
+            "nutritionist_id": 99,
+            "start_date": "invalid-date",
+            "end_date": "also-invalid",
+            "meal_details": "Details",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Invalid date format. Expected YYYY-MM-DD."
 
 
 def test_message_conversation_flow(base_url):
@@ -186,3 +219,18 @@ def test_appointment_workflow(base_url):
     not_found = requests.get(f"{base_url}/appointments/{appointment_id + 1}")
     assert not_found.status_code == 404
     assert not_found.json()["message"] == "Appointment not found"
+
+
+def test_create_appointment_with_invalid_datetime_returns_400(base_url):
+    client_id = create_user(base_url, "apptclient", "apptclient@example.com")
+    nutritionist_id = create_user(base_url, "apptnut", "apptnut@example.com")
+    response = requests.post(
+        f"{base_url}/appointments",
+        json={
+            "client_id": client_id,
+            "nutritionist_id": nutritionist_id,
+            "scheduled_at": "invalid",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Invalid datetime format. Expected YYYY-MM-DD HH:MM:SS."


### PR DESCRIPTION
## Summary
- add defensive validation for diet plan and appointment creation endpoints to reject malformed dates
- expand route integration tests to cover pre-hashed passwords and date validation error paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbb1a9d1ac8322ae769a73d8d18a0b