### PR TITLE
Add JWT auth and role-based access controls

### DIFF
--- a/alembic/versions/5f5d4b4c2a1b_add_role_column_to_users.py
+++ b/alembic/versions/5f5d4b4c2a1b_add_role_column_to_users.py
@@ -1,0 +1,26 @@
+"""Add role column to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5f5d4b4c2a1b'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.add_column(sa.Column('role', sa.String(length=20), nullable=True, server_default='client'))
+
+    op.execute("UPDATE users SET role='client' WHERE role IS NULL")
+
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.alter_column('role', existing_type=sa.String(length=20), nullable=False, server_default='client')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_column('role')

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,201 @@
+"""Utility helpers for issuing and validating JWT access tokens."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from functools import wraps
+from typing import Iterable, Optional, Set
+
+try:  # pragma: no cover - exercised when PyJWT is installed
+    import jwt  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback implementation
+    jwt = None
+
+from flask import Response, g, jsonify, request
+
+
+class AuthError(Exception):
+    """Raised when authentication fails."""
+
+    def __init__(self, message: str, status_code: int = 401) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _get_secret_key() -> str:
+    secret = os.getenv("JWT_SECRET_KEY")
+    if not secret:
+        # Provide a deterministic secret for testing environments while encouraging
+        # production deployments to configure one explicitly.
+        secret = "dev-secret-key"
+    return secret
+
+
+def _get_expiry_delta() -> timedelta:
+    raw = os.getenv("JWT_ACCESS_TOKEN_EXPIRES", "3600")
+    try:
+        seconds = int(raw)
+    except ValueError as exc:  # pragma: no cover - guardrail for misconfiguration
+        raise AuthError("Invalid JWT_ACCESS_TOKEN_EXPIRES value", status_code=500) from exc
+    return timedelta(seconds=seconds)
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _encode_jwt(payload: dict, secret: str) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    header_segment = _b64encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_segment = _b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_segment}.{payload_segment}".encode("utf-8")
+    signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    signature_segment = _b64encode(signature)
+    return f"{header_segment}.{payload_segment}.{signature_segment}"
+
+
+def _decode_jwt(token: str, secret: str) -> dict:
+    try:
+        header_segment, payload_segment, signature_segment = token.split(".")
+    except ValueError as exc:
+        raise AuthError("Invalid token") from exc
+
+    signing_input = f"{header_segment}.{payload_segment}".encode("utf-8")
+    expected_signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    actual_signature = _b64decode(signature_segment)
+    if not hmac.compare_digest(expected_signature, actual_signature):
+        raise AuthError("Invalid token")
+
+    header = json.loads(_b64decode(header_segment))
+    if header.get("alg") != "HS256":
+        raise AuthError("Unsupported token algorithm")
+
+    return json.loads(_b64decode(payload_segment))
+
+
+def create_access_token(*, user_id: int, role: str, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a signed JWT encoding the user identifier and role."""
+
+    expiry = expires_delta or _get_expiry_delta()
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "role": role,
+        "iat": int(now.timestamp()),
+        "exp": int((now + expiry).timestamp()),
+    }
+    secret = _get_secret_key()
+    if jwt is not None:
+        token = jwt.encode(payload, secret, algorithm="HS256")
+        if isinstance(token, bytes):  # pragma: no cover - depends on PyJWT configuration
+            token = token.decode("utf-8")
+        return token
+    return _encode_jwt(payload, secret)
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode and validate a JWT, returning the embedded payload."""
+    secret = _get_secret_key()
+    if jwt is not None:
+        try:
+            payload = jwt.decode(token, secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError as exc:
+            raise AuthError("Token has expired") from exc
+        except jwt.InvalidTokenError as exc:
+            raise AuthError("Invalid token") from exc
+    else:
+        payload = _decode_jwt(token, secret)
+        exp_timestamp = payload.get("exp")
+        if exp_timestamp is None:
+            raise AuthError("Token missing expiration")
+        if datetime.now(timezone.utc).timestamp() > float(exp_timestamp):
+            raise AuthError("Token has expired")
+
+    if "sub" not in payload:
+        raise AuthError("Token missing subject")
+    if "role" not in payload:
+        raise AuthError("Token missing role")
+    return payload
+
+
+def _extract_bearer_token() -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header:
+        raise AuthError("Authorization header missing")
+
+    parts = auth_header.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise AuthError("Invalid authorization header")
+    return parts[1]
+
+
+def jwt_required(
+    *, roles: Optional[Iterable[str]] = None, allow_self_kw: Optional[str] = None
+):
+    """Decorator enforcing that the request contains a valid JWT.
+
+    Args:
+        roles: Optional collection of roles allowed to access the endpoint.
+        allow_self_kw: Name of a keyword argument that identifies a user id in the
+            route. If supplied, a caller whose ``sub`` matches that value is
+            permitted even if their role is not present in ``roles``.
+    """
+
+    allowed_roles: Optional[Set[str]] = set(roles) if roles is not None else None
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                token = _extract_bearer_token()
+                payload = decode_access_token(token)
+            except AuthError as exc:
+                return jsonify({"error": str(exc)}), exc.status_code
+
+            current_user = {
+                "user_id": payload.get("sub"),
+                "role": payload.get("role"),
+            }
+            g.current_user = current_user
+
+            authorized = True
+            if allowed_roles is not None:
+                authorized = current_user["role"] in allowed_roles
+
+            if not authorized and allow_self_kw is not None:
+                target_user_id = kwargs.get(allow_self_kw)
+                if target_user_id is not None and target_user_id == current_user["user_id"]:
+                    authorized = True
+
+            if not authorized:
+                return jsonify({"error": "Forbidden"}), 403
+
+            response: Response = func(*args, **kwargs)
+            return response
+
+        return wrapper
+
+    return decorator
+
+
+def current_user() -> Optional[dict]:
+    """Return the JWT payload for the active request, if present."""
+
+    return getattr(g, "current_user", None)
+
+
+def access_token_expires_in() -> int:
+    """Return the configured lifetime (in seconds) for generated tokens."""
+
+    return int(_get_expiry_delta().total_seconds())
+

--- a/api/models.py
+++ b/api/models.py
@@ -9,6 +9,7 @@ class User(Base):
     username = Column(String(50), unique=True, nullable=False)
     email = Column(String(100), unique=True, nullable=False)
     password_hash = Column(String(200), nullable=False)
+    role = Column(String(20), nullable=False, default='client')
     full_name = Column(String(100))
     gender = Column(String(10))
     age = Column(Integer)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,5 @@ Flask==2.0.2
 Werkzeug==2.0.3
 SQLAlchemy==1.4.22
 psycopg2-binary==2.9.7
+PyJWT==2.8.0
+alembic==1.13.1

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,10 +1,14 @@
-from flask import Blueprint, request, jsonify, render_template
+from flask import Blueprint, request, jsonify, render_template, g
 from datetime import datetime
-from werkzeug.security import generate_password_hash
+from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy import or_
 from database import SessionLocal
 from models import User, UserProgress, DietPlan, WorkoutPlan, Message, Appointment
+from auth import access_token_expires_in, create_access_token, current_user, jwt_required
 
 bp = Blueprint('api', __name__)
+
+VALID_ROLES = {'client', 'nutritionist', 'admin'}
 
 # --------------------------------
 # Simple Frontend
@@ -17,28 +21,32 @@ def index():
 # Users Endpoints
 # --------------------------------
 @bp.route('/users', methods=['GET'])
+@jwt_required(roles={'admin'})
 def get_users():
     session = SessionLocal()
-    users = session.query(User).all()
-    result = []
-    for user in users:
-        result.append({
-            "user_id": user.user_id,
-            "username": user.username,
-            "email": user.email,
-            "full_name": user.full_name,
-            "gender": user.gender,
-            "age": user.age,
-            "weight": float(user.weight) if user.weight else None,
-            "height": float(user.height) if user.height else None,
-            "goal": user.goal
-        })
-    session.close()
-    return jsonify(result)
+    try:
+        users = session.query(User).all()
+        result = []
+        for user in users:
+            result.append({
+                "user_id": user.user_id,
+                "username": user.username,
+                "email": user.email,
+                "full_name": user.full_name,
+                "gender": user.gender,
+                "age": user.age,
+                "weight": float(user.weight) if user.weight else None,
+                "height": float(user.height) if user.height else None,
+                "goal": user.goal,
+                "role": user.role,
+            })
+        return jsonify(result)
+    finally:
+        session.close()
 
 @bp.route('/users', methods=['POST'])
 def create_user():
-    data = request.get_json()
+    data = request.get_json() or {}
     session = SessionLocal()
 
     # Support clients sending either a plain password or a precomputed hash
@@ -50,50 +58,97 @@ def create_user():
         session.close()
         return jsonify({"error": "Password is required"}), 400
 
-    new_user = User(
-        username=data['username'],
-        email=data['email'],
-        password_hash=password_hash,
-        full_name=data.get('full_name'),
-        gender=data.get('gender'),
-        age=data.get('age'),
-        weight=data.get('weight'),
-        height=data.get('height'),
-        goal=data.get('goal'),
-        neck_circumference=data.get('neck_circumference'),
-        abdomen_circumference=data.get('abdomen_circumference'),
-        hip_circumference=data.get('hip_circumference'),
-        underlying_medical_conditions=data.get('underlying_medical_conditions')
-    )
-    session.add(new_user)
-    session.commit()
-    session.refresh(new_user)
-    session.close()
-    return jsonify({"message": "User created successfully", "user_id": new_user.user_id}), 201
+    role = data.get('role', 'client')
+    if role not in VALID_ROLES:
+        session.close()
+        return jsonify({"error": "Invalid role"}), 400
+
+    try:
+        new_user = User(
+            username=data['username'],
+            email=data['email'],
+            password_hash=password_hash,
+            role=role,
+            full_name=data.get('full_name'),
+            gender=data.get('gender'),
+            age=data.get('age'),
+            weight=data.get('weight'),
+            height=data.get('height'),
+            goal=data.get('goal'),
+            neck_circumference=data.get('neck_circumference'),
+            abdomen_circumference=data.get('abdomen_circumference'),
+            hip_circumference=data.get('hip_circumference'),
+            underlying_medical_conditions=data.get('underlying_medical_conditions')
+        )
+        session.add(new_user)
+        session.commit()
+        session.refresh(new_user)
+        return jsonify({"message": "User created successfully", "user_id": new_user.user_id, "role": new_user.role}), 201
+    finally:
+        session.close()
+
+
+# --------------------------------
+# Authentication Endpoints
+# --------------------------------
+@bp.route('/auth/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    identifier = data.get('username') or data.get('email')
+    password = data.get('password')
+    if not identifier or not password:
+        return jsonify({"error": "Username/email and password are required"}), 400
+
+    session = SessionLocal()
+    try:
+        user = session.query(User).filter(
+            or_(User.username == identifier, User.email == identifier)
+        ).first()
+        if not user or not check_password_hash(user.password_hash, password):
+            return jsonify({"error": "Invalid credentials"}), 401
+
+        token = create_access_token(user_id=user.user_id, role=user.role)
+        return jsonify({
+            "access_token": token,
+            "token_type": "Bearer",
+            "expires_in": access_token_expires_in(),
+            "user": {
+                "user_id": user.user_id,
+                "username": user.username,
+                "role": user.role,
+            },
+        })
+    finally:
+        session.close()
+
 
 # --------------------------------
 # Diet Plans Endpoints
 # --------------------------------
 @bp.route('/users/<int:user_id>/diet_plans', methods=['GET'])
+@jwt_required(roles={'admin', 'nutritionist'}, allow_self_kw='user_id')
 def get_diet_plans(user_id):
     session = SessionLocal()
-    diet_plans = session.query(DietPlan).filter(DietPlan.user_id == user_id).all()
-    result = []
-    for plan in diet_plans:
-        result.append({
-            "diet_id": plan.diet_id,
-            "start_date": plan.start_date.isoformat() if plan.start_date else None,
-            "end_date": plan.end_date.isoformat() if plan.end_date else None,
-            "meal_details": plan.meal_details,
-            "preferences_client_notes": plan.preferences_client_notes,
-            "notes": plan.notes
-        })
-    session.close()
-    return jsonify(result)
+    try:
+        diet_plans = session.query(DietPlan).filter(DietPlan.user_id == user_id).all()
+        result = []
+        for plan in diet_plans:
+            result.append({
+                "diet_id": plan.diet_id,
+                "start_date": plan.start_date.isoformat() if plan.start_date else None,
+                "end_date": plan.end_date.isoformat() if plan.end_date else None,
+                "meal_details": plan.meal_details,
+                "preferences_client_notes": plan.preferences_client_notes,
+                "notes": plan.notes
+            })
+        return jsonify(result)
+    finally:
+        session.close()
 
 @bp.route('/users/<int:user_id>/diet_plans', methods=['POST'])
+@jwt_required(roles={'admin', 'nutritionist'}, allow_self_kw='user_id')
 def create_diet_plan(user_id):
-    data = request.get_json()
+    data = request.get_json() or {}
     session = SessionLocal()
     try:
         try:
@@ -102,9 +157,15 @@ def create_diet_plan(user_id):
         except (KeyError, TypeError, ValueError):
             return jsonify({"error": "Invalid date format. Expected YYYY-MM-DD."}), 400
 
+        acting_user = current_user()
+        if acting_user['role'] == 'client' and acting_user['user_id'] != user_id:
+            return jsonify({"error": "Forbidden"}), 403
+
         new_diet_plan = DietPlan(
             user_id=user_id,
-            nutritionist_id=data.get('nutritionist_id'),
+            nutritionist_id=data.get('nutritionist_id') or (
+                acting_user['user_id'] if acting_user['role'] in {'nutritionist', 'admin'} else None
+            ),
             start_date=start_date,
             end_date=end_date,
             meal_details=data['meal_details'],
@@ -122,48 +183,75 @@ def create_diet_plan(user_id):
 # Messages Endpoints
 # --------------------------------
 @bp.route('/messages', methods=['POST'])
+@jwt_required()
 def send_message():
-    data = request.get_json()
+    data = request.get_json() or {}
+    sender_id = data.get('sender_id')
+    receiver_id = data.get('receiver_id')
+    message_content = data.get('message_content')
+
+    if sender_id is None or receiver_id is None or not message_content:
+        return jsonify({"error": "sender_id, receiver_id, and message_content are required"}), 400
+
+    acting_user = current_user()
+    if acting_user['role'] != 'admin' and acting_user['user_id'] != sender_id:
+        return jsonify({"error": "Forbidden"}), 403
+
     session = SessionLocal()
-    new_message = Message(
-        sender_id=data['sender_id'],
-        receiver_id=data['receiver_id'],
-        message_content=data['message_content']
-    )
-    session.add(new_message)
-    session.commit()
-    session.refresh(new_message)
-    session.close()
-    return jsonify({"message": "Message sent successfully", "message_id": new_message.message_id}), 201
+    try:
+        new_message = Message(
+            sender_id=sender_id,
+            receiver_id=receiver_id,
+            message_content=message_content
+        )
+        session.add(new_message)
+        session.commit()
+        session.refresh(new_message)
+        return jsonify({"message": "Message sent successfully", "message_id": new_message.message_id}), 201
+    finally:
+        session.close()
+
 
 @bp.route('/messages/conversation', methods=['GET'])
+@jwt_required()
 def get_conversation():
     user1_id = request.args.get('user1_id', type=int)
     user2_id = request.args.get('user2_id', type=int)
+
+    if user1_id is None or user2_id is None:
+        return jsonify({"error": "user1_id and user2_id are required"}), 400
+
+    acting_user = current_user()
+    if acting_user['role'] != 'admin' and acting_user['user_id'] not in {user1_id, user2_id}:
+        return jsonify({"error": "Forbidden"}), 403
+
     session = SessionLocal()
-    messages = session.query(Message).filter(
-        ((Message.sender_id == user1_id) & (Message.receiver_id == user2_id)) |
-        ((Message.sender_id == user2_id) & (Message.receiver_id == user1_id))
-    ).order_by(Message.sent_at).all()
-    result = []
-    for msg in messages:
-        result.append({
-            "message_id": msg.message_id,
-            "sender_id": msg.sender_id,
-            "receiver_id": msg.receiver_id,
-            "sent_at": msg.sent_at.isoformat(),
-            "message_content": msg.message_content,
-            "is_read": msg.is_read
-        })
-    session.close()
-    return jsonify(result)
+    try:
+        messages = session.query(Message).filter(
+            ((Message.sender_id == user1_id) & (Message.receiver_id == user2_id)) |
+            ((Message.sender_id == user2_id) & (Message.receiver_id == user1_id))
+        ).order_by(Message.sent_at).all()
+        result = []
+        for msg in messages:
+            result.append({
+                "message_id": msg.message_id,
+                "sender_id": msg.sender_id,
+                "receiver_id": msg.receiver_id,
+                "sent_at": msg.sent_at.isoformat(),
+                "message_content": msg.message_content,
+                "is_read": msg.is_read
+            })
+        return jsonify(result)
+    finally:
+        session.close()
 
 # --------------------------------
 # Appointments Endpoints
 # --------------------------------
 @bp.route('/appointments', methods=['POST'])
+@jwt_required()
 def create_appointment():
-    data = request.get_json()
+    data = request.get_json() or {}
     session = SessionLocal()
     try:
         try:
@@ -171,9 +259,19 @@ def create_appointment():
         except (KeyError, TypeError, ValueError):
             return jsonify({"error": "Invalid datetime format. Expected YYYY-MM-DD HH:MM:SS."}), 400
 
+        client_id = data.get('client_id')
+        nutritionist_id = data.get('nutritionist_id')
+        if client_id is None or nutritionist_id is None:
+            return jsonify({"error": "client_id and nutritionist_id are required"}), 400
+
+        acting_user = current_user()
+        allowed_roles = {'admin', 'nutritionist'}
+        if acting_user['role'] not in allowed_roles and acting_user['user_id'] not in {client_id, nutritionist_id}:
+            return jsonify({"error": "Forbidden"}), 403
+
         new_appointment = Appointment(
-            client_id=data['client_id'],
-            nutritionist_id=data['nutritionist_id'],
+            client_id=client_id,
+            nutritionist_id=nutritionist_id,
             scheduled_at=scheduled_at,
             status=data.get('status', 'scheduled'),
             google_calendar_event_id=data.get('google_calendar_event_id')
@@ -185,11 +283,21 @@ def create_appointment():
     finally:
         session.close()
 
+
 @bp.route('/appointments/<int:appointment_id>', methods=['GET'])
+@jwt_required()
 def get_appointment(appointment_id):
     session = SessionLocal()
-    appointment = session.query(Appointment).filter(Appointment.appointment_id == appointment_id).first()
-    if appointment:
+    try:
+        appointment = session.query(Appointment).filter(Appointment.appointment_id == appointment_id).first()
+        if not appointment:
+            return jsonify({"message": "Appointment not found"}), 404
+
+        acting_user = current_user()
+        allowed_roles = {'admin', 'nutritionist'}
+        if acting_user['role'] not in allowed_roles and acting_user['user_id'] not in {appointment.client_id, appointment.nutritionist_id}:
+            return jsonify({"error": "Forbidden"}), 403
+
         result = {
             "appointment_id": appointment.appointment_id,
             "client_id": appointment.client_id,
@@ -198,24 +306,26 @@ def get_appointment(appointment_id):
             "status": appointment.status,
             "google_calendar_event_id": appointment.google_calendar_event_id
         }
-        session.close()
         return jsonify(result)
-    else:
+    finally:
         session.close()
-        return jsonify({"message": "Appointment not found"}), 404
+
 
 @bp.route('/appointments', methods=['GET'])
+@jwt_required(roles={'admin', 'nutritionist'})
 def list_appointments():
     session = SessionLocal()
-    appointments = session.query(Appointment).all()
-    result = []
-    for appt in appointments:
-        result.append({
-            "appointment_id": appt.appointment_id,
-            "client_id": appt.client_id,
-            "nutritionist_id": appt.nutritionist_id,
-            "scheduled_at": appt.scheduled_at.isoformat(),
-            "status": appt.status
-        })
-    session.close()
-    return jsonify(result)
+    try:
+        appointments = session.query(Appointment).all()
+        result = []
+        for appt in appointments:
+            result.append({
+                "appointment_id": appt.appointment_id,
+                "client_id": appt.client_id,
+                "nutritionist_id": appt.nutritionist_id,
+                "scheduled_at": appt.scheduled_at.isoformat(),
+                "status": appt.status
+            })
+        return jsonify(result)
+    finally:
+        session.close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest==7.4.4
 requests==2.31.0
+PyJWT==2.8.0
+alembic==1.13.1

--- a/tests/_requests_stub.py
+++ b/tests/_requests_stub.py
@@ -36,15 +36,15 @@ class Response:
         return json_module.loads(self._body.decode("utf-8"))
 
 
-def _request(method: str, url: str, *, params=None, json=None):
+def _request(method: str, url: str, *, params=None, json=None, headers=None):
     target = _prepare_url(url, params)
     data = None
-    headers = {}
+    request_headers = headers.copy() if headers else {}
     if json is not None:
         data = json_module.dumps(json).encode("utf-8")
-        headers["Content-Type"] = "application/json"
+        request_headers["Content-Type"] = "application/json"
     request = Request(target, data=data, method=method.upper())
-    for key, value in headers.items():
+    for key, value in request_headers.items():
         request.add_header(key, value)
     try:
         with urlopen(request) as response:  # nosec B310 - only used in tests
@@ -57,12 +57,12 @@ def _request(method: str, url: str, *, params=None, json=None):
         raise ConnectionError(str(exc)) from exc
 
 
-def get(url: str, params=None):
-    return _request("GET", url, params=params)
+def get(url: str, params=None, headers=None):
+    return _request("GET", url, params=params, headers=headers)
 
 
-def post(url: str, json=None):
-    return _request("POST", url, json=json)
+def post(url: str, json=None, headers=None):
+    return _request("POST", url, json=json, headers=headers)
 
 
 exceptions = SimpleNamespace(ConnectionError=ConnectionError)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timedelta
 
+import pytest
 from werkzeug.security import generate_password_hash
 
 try:  # pragma: no cover - exercised when requests is available
@@ -9,23 +10,117 @@ except ModuleNotFoundError:  # pragma: no cover - offline fallback
     from . import _requests_stub as requests
 
 
-def create_user(base_url, username, email, **extra):
+DEFAULT_PASSWORD = "strongpassword"
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_user(
+    base_url: str,
+    username: str,
+    email: str,
+    *,
+    password: str | None = DEFAULT_PASSWORD,
+    password_hash: str | None = None,
+    role: str = "client",
+    **extra,
+) -> int:
     payload = {
         "username": username,
         "email": email,
-        "password": "strongpassword",
         "full_name": extra.get("full_name", "Test User"),
         "gender": extra.get("gender", "non-binary"),
         "age": extra.get("age", 30),
         "weight": extra.get("weight", 70.5),
         "height": extra.get("height", 175.0),
         "goal": extra.get("goal", "Maintain weight"),
+        "role": role,
     }
+
+    if password_hash is not None:
+        payload["password_hash"] = password_hash
+    else:
+        payload["password"] = password or DEFAULT_PASSWORD
+
     response = requests.post(f"{base_url}/users", json=payload)
     assert response.status_code == 201, response.text
     data = response.json()
     assert "user_id" in data
     return data["user_id"]
+
+
+def login_user(
+    base_url: str,
+    *,
+    username: str | None = None,
+    email: str | None = None,
+    password: str = DEFAULT_PASSWORD,
+) -> dict:
+    credentials: dict[str, str] = {"password": password}
+    if username:
+        credentials["username"] = username
+    if email:
+        credentials["email"] = email
+
+    response = requests.post(f"{base_url}/auth/login", json=credentials)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "access_token" in data
+    return data
+
+
+def create_authenticated_user(
+    base_url: str,
+    username: str,
+    email: str,
+    *,
+    password: str = DEFAULT_PASSWORD,
+    role: str = "client",
+    **extra,
+) -> dict:
+    user_id = create_user(
+        base_url,
+        username,
+        email,
+        password=password,
+        role=role,
+        **extra,
+    )
+    token_data = login_user(base_url, username=username, password=password)
+    token = token_data["access_token"]
+    return {
+        "user_id": user_id,
+        "username": username,
+        "email": email,
+        "password": password,
+        "role": role,
+        "token": token,
+        "headers": auth_headers(token),
+    }
+
+
+@pytest.fixture
+def admin_auth(base_url):
+    return create_authenticated_user(
+        base_url,
+        "admin_user",
+        "admin@example.com",
+        password="adminpass",
+        role="admin",
+    )
+
+
+@pytest.fixture
+def nutritionist_auth(base_url):
+    return create_authenticated_user(
+        base_url,
+        "nutritionist",
+        "nutritionist@example.com",
+        password="nutpass",
+        role="nutritionist",
+    )
 
 
 def test_index_page_loads(base_url):
@@ -34,41 +129,36 @@ def test_index_page_loads(base_url):
     assert "Welcome to the Diet Appointments Dashboard" in response.text
 
 
-def test_user_creation_and_listing(base_url):
+def test_user_creation_and_listing(base_url, admin_auth):
     username = "integration_user"
     email = "integration@example.com"
-    response = requests.post(
-        f"{base_url}/users",
-        json={
-            "username": username,
-            "email": email,
-            "password": "anotherpassword",
-            "full_name": "Integration Tester",
-            "gender": "female",
-            "age": 28,
-            "weight": 62.3,
-            "height": 168.2,
-            "goal": "Build muscle",
-            "neck_circumference": 34.1,
-            "abdomen_circumference": 72.4,
-            "hip_circumference": 95.0,
-            "underlying_medical_conditions": "None",
-        },
+    create_user(
+        base_url,
+        username,
+        email,
+        password="anotherpassword",
+        full_name="Integration Tester",
+        gender="female",
+        age=28,
+        weight=62.3,
+        height=168.2,
+        goal="Build muscle",
     )
-    assert response.status_code == 201
-    user_id = response.json()["user_id"]
-    assert user_id > 0
 
-    list_response = requests.get(f"{base_url}/users")
+    unauthorized = requests.get(f"{base_url}/users")
+    assert unauthorized.status_code == 401
+
+    list_response = requests.get(f"{base_url}/users", headers=admin_auth["headers"])
     assert list_response.status_code == 200
     users = list_response.json()
-    assert len(users) == 1
-    user = users[0]
-    assert user["username"] == username
+    matching = [u for u in users if u["username"] == username]
+    assert matching
+    user = matching[0]
     assert user["email"] == email
     assert user["goal"] == "Build muscle"
     assert user["weight"] == 62.3
     assert user["height"] == 168.2
+    assert user["role"] == "client"
 
 
 def test_user_creation_requires_password(base_url):
@@ -83,43 +173,79 @@ def test_user_creation_requires_password(base_url):
     assert response.json()["error"] == "Password is required"
 
 
-def test_user_creation_accepts_prehashed_password(base_url):
+def test_user_creation_accepts_prehashed_password(base_url, admin_auth):
     hashed_password = generate_password_hash("already_secure")
-    response = requests.post(
-        f"{base_url}/users",
-        json={
-            "username": "prehashed",
-            "email": "prehashed@example.com",
-            "password_hash": hashed_password,
-        },
+    create_user(
+        base_url,
+        "prehashed",
+        "prehashed@example.com",
+        password=None,
+        password_hash=hashed_password,
     )
-    assert response.status_code == 201
 
-    users = requests.get(f"{base_url}/users").json()
-    assert users[0]["username"] == "prehashed"
+    login_data = login_user(base_url, username="prehashed", password="already_secure")
+    assert login_data["user"]["role"] == "client"
+
+    users = requests.get(f"{base_url}/users", headers=admin_auth["headers"]).json()
+    assert any(u["username"] == "prehashed" for u in users)
 
 
-def test_diet_plan_creation_and_retrieval(base_url):
-    user_id = create_user(base_url, "dietuser", "diet@example.com")
+def test_login_returns_token_and_role(base_url):
+    password = "safepassword"
+    create_user(base_url, "login_user", "login@example.com", password=password)
+
+    response = requests.post(
+        f"{base_url}/auth/login",
+        json={"username": "login_user", "password": password},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["token_type"] == "Bearer"
+    assert data["user"]["role"] == "client"
+
+
+def test_diet_plan_creation_and_retrieval(base_url, nutritionist_auth):
+    client = create_authenticated_user(
+        base_url,
+        "dietclient",
+        "dietclient@example.com",
+        password="clientpass",
+    )
 
     start_date = datetime.utcnow().date()
     end_date = start_date + timedelta(days=30)
+    payload = {
+        "start_date": start_date.strftime("%Y-%m-%d"),
+        "end_date": end_date.strftime("%Y-%m-%d"),
+        "meal_details": "High protein diet",
+        "preferences_client_notes": "No peanuts",
+        "notes": "Follow-up in two weeks",
+    }
+
+    unauthorized = requests.post(
+        f"{base_url}/users/{client['user_id']}/diet_plans",
+        json=payload,
+    )
+    assert unauthorized.status_code == 401
+
     response = requests.post(
-        f"{base_url}/users/{user_id}/diet_plans",
-        json={
-            "nutritionist_id": 42,
-            "start_date": start_date.strftime("%Y-%m-%d"),
-            "end_date": end_date.strftime("%Y-%m-%d"),
-            "meal_details": "High protein diet",
-            "preferences_client_notes": "No peanuts",
-            "notes": "Follow-up in two weeks",
-        },
+        f"{base_url}/users/{client['user_id']}/diet_plans",
+        json=payload,
+        headers=nutritionist_auth["headers"],
     )
     assert response.status_code == 201
     diet_id = response.json()["diet_id"]
     assert diet_id > 0
 
-    list_response = requests.get(f"{base_url}/users/{user_id}/diet_plans")
+    unauthorized_get = requests.get(
+        f"{base_url}/users/{client['user_id']}/diet_plans",
+    )
+    assert unauthorized_get.status_code == 401
+
+    list_response = requests.get(
+        f"{base_url}/users/{client['user_id']}/diet_plans",
+        headers=client["headers"],
+    )
     assert list_response.status_code == 200
     diet_plans = list_response.json()
     assert len(diet_plans) == 1
@@ -131,106 +257,208 @@ def test_diet_plan_creation_and_retrieval(base_url):
     assert plan["end_date"].startswith(end_date.isoformat())
 
 
-def test_diet_plan_creation_with_invalid_dates_returns_400(base_url):
-    user_id = create_user(base_url, "dietuser2", "diet2@example.com")
+def test_diet_plan_creation_with_invalid_dates_returns_400(base_url, nutritionist_auth):
+    client = create_authenticated_user(
+        base_url,
+        "dietuser2",
+        "diet2@example.com",
+        password="clientpass2",
+    )
+
     response = requests.post(
-        f"{base_url}/users/{user_id}/diet_plans",
+        f"{base_url}/users/{client['user_id']}/diet_plans",
         json={
-            "nutritionist_id": 99,
             "start_date": "invalid-date",
             "end_date": "also-invalid",
             "meal_details": "Details",
         },
+        headers=nutritionist_auth["headers"],
     )
     assert response.status_code == 400
     assert response.json()["error"] == "Invalid date format. Expected YYYY-MM-DD."
 
 
+def test_client_cannot_create_plan_for_other_user(base_url):
+    client = create_authenticated_user(
+        base_url,
+        "client_a",
+        "client_a@example.com",
+        password="clientapass",
+    )
+    other = create_authenticated_user(
+        base_url,
+        "client_b",
+        "client_b@example.com",
+        password="clientbpass",
+    )
+
+    response = requests.post(
+        f"{base_url}/users/{other['user_id']}/diet_plans",
+        json={
+            "start_date": datetime.utcnow().strftime("%Y-%m-%d"),
+            "end_date": (datetime.utcnow() + timedelta(days=7)).strftime("%Y-%m-%d"),
+            "meal_details": "Sample",
+        },
+        headers=client["headers"],
+    )
+    assert response.status_code == 403
+    assert response.json()["error"] == "Forbidden"
+
+
 def test_message_conversation_flow(base_url):
-    sender_id = create_user(base_url, "sender", "sender@example.com")
-    receiver_id = create_user(base_url, "receiver", "receiver@example.com")
+    sender = create_authenticated_user(
+        base_url,
+        "sender",
+        "sender@example.com",
+        password="senderpass",
+    )
+    receiver = create_authenticated_user(
+        base_url,
+        "receiver",
+        "receiver@example.com",
+        password="receiverpass",
+    )
 
     first_message = {
-        "sender_id": sender_id,
-        "receiver_id": receiver_id,
+        "sender_id": sender["user_id"],
+        "receiver_id": receiver["user_id"],
         "message_content": "Hello there!",
     }
-    response = requests.post(f"{base_url}/messages", json=first_message)
+
+    unauthorized = requests.post(f"{base_url}/messages", json=first_message)
+    assert unauthorized.status_code == 401
+
+    wrong_user = requests.post(
+        f"{base_url}/messages",
+        json=first_message,
+        headers=receiver["headers"],
+    )
+    assert wrong_user.status_code == 403
+
+    response = requests.post(
+        f"{base_url}/messages",
+        json=first_message,
+        headers=sender["headers"],
+    )
     assert response.status_code == 201
 
     time.sleep(0.05)
 
     second_message = {
-        "sender_id": receiver_id,
-        "receiver_id": sender_id,
+        "sender_id": receiver["user_id"],
+        "receiver_id": sender["user_id"],
         "message_content": "Hi! Great to hear from you.",
     }
-    response = requests.post(f"{base_url}/messages", json=second_message)
+    response = requests.post(
+        f"{base_url}/messages",
+        json=second_message,
+        headers=receiver["headers"],
+    )
     assert response.status_code == 201
 
-    conversation = requests.get(
-        f"{base_url}/messages/conversation",
-        params={"user1_id": sender_id, "user2_id": receiver_id},
+    conversation_url = f"{base_url}/messages/conversation"
+    params = {"user1_id": sender["user_id"], "user2_id": receiver["user_id"]}
+
+    unauthorized_get = requests.get(conversation_url, params=params)
+    assert unauthorized_get.status_code == 401
+
+    intruder = create_authenticated_user(
+        base_url,
+        "intruder",
+        "intruder@example.com",
+        password="intruderpass",
     )
+    forbidden = requests.get(conversation_url, params=params, headers=intruder["headers"])
+    assert forbidden.status_code == 403
+
+    conversation = requests.get(conversation_url, params=params, headers=sender["headers"])
     assert conversation.status_code == 200
     messages = conversation.json()
     assert [m["message_content"] for m in messages] == [
         "Hello there!",
         "Hi! Great to hear from you.",
     ]
-    assert messages[0]["sender_id"] == sender_id
-    assert messages[1]["sender_id"] == receiver_id
+    assert messages[0]["sender_id"] == sender["user_id"]
+    assert messages[1]["sender_id"] == receiver["user_id"]
 
 
-def test_appointment_workflow(base_url):
-    client_id = create_user(base_url, "client", "client@example.com")
-    nutritionist_id = create_user(base_url, "nutritionist", "nutritionist@example.com")
+def test_appointment_workflow(base_url, nutritionist_auth):
+    client = create_authenticated_user(
+        base_url,
+        "client",
+        "client@example.com",
+        password="clientpass",
+    )
 
     scheduled_at = datetime.utcnow().replace(microsecond=0)
+    payload = {
+        "client_id": client["user_id"],
+        "nutritionist_id": nutritionist_auth["user_id"],
+        "scheduled_at": scheduled_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "status": "confirmed",
+        "google_calendar_event_id": "event123",
+    }
+
+    unauthorized = requests.post(f"{base_url}/appointments", json=payload)
+    assert unauthorized.status_code == 401
+
     response = requests.post(
         f"{base_url}/appointments",
-        json={
-            "client_id": client_id,
-            "nutritionist_id": nutritionist_id,
-            "scheduled_at": scheduled_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "status": "confirmed",
-            "google_calendar_event_id": "event123",
-        },
+        json=payload,
+        headers=nutritionist_auth["headers"],
     )
     assert response.status_code == 201
     appointment_id = response.json()["appointment_id"]
 
-    detail_response = requests.get(f"{base_url}/appointments/{appointment_id}")
+    detail_unauthorized = requests.get(f"{base_url}/appointments/{appointment_id}")
+    assert detail_unauthorized.status_code == 401
+
+    detail_response = requests.get(
+        f"{base_url}/appointments/{appointment_id}",
+        headers=client["headers"],
+    )
     assert detail_response.status_code == 200
     appointment = detail_response.json()
     assert appointment["appointment_id"] == appointment_id
-    assert appointment["client_id"] == client_id
-    assert appointment["nutritionist_id"] == nutritionist_id
+    assert appointment["client_id"] == client["user_id"]
+    assert appointment["nutritionist_id"] == nutritionist_auth["user_id"]
     assert appointment["status"] == "confirmed"
     assert appointment["google_calendar_event_id"] == "event123"
     assert appointment["scheduled_at"].startswith(scheduled_at.isoformat())
 
-    list_response = requests.get(f"{base_url}/appointments")
+    list_response = requests.get(
+        f"{base_url}/appointments",
+        headers=nutritionist_auth["headers"],
+    )
     assert list_response.status_code == 200
     appointments = list_response.json()
     assert len(appointments) == 1
     assert appointments[0]["appointment_id"] == appointment_id
 
-    not_found = requests.get(f"{base_url}/appointments/{appointment_id + 1}")
+    not_found = requests.get(
+        f"{base_url}/appointments/{appointment_id + 1}",
+        headers=nutritionist_auth["headers"],
+    )
     assert not_found.status_code == 404
     assert not_found.json()["message"] == "Appointment not found"
 
 
-def test_create_appointment_with_invalid_datetime_returns_400(base_url):
-    client_id = create_user(base_url, "apptclient", "apptclient@example.com")
-    nutritionist_id = create_user(base_url, "apptnut", "apptnut@example.com")
+def test_create_appointment_with_invalid_datetime_returns_400(base_url, nutritionist_auth):
+    client = create_authenticated_user(
+        base_url,
+        "apptclient",
+        "apptclient@example.com",
+        password="apptclientpass",
+    )
+
     response = requests.post(
         f"{base_url}/appointments",
         json={
-            "client_id": client_id,
-            "nutritionist_id": nutritionist_id,
+            "client_id": client["user_id"],
+            "nutritionist_id": nutritionist_auth["user_id"],
             "scheduled_at": "invalid",
         },
+        headers=nutritionist_auth["headers"],
     )
     assert response.status_code == 400
     assert response.json()["error"] == "Invalid datetime format. Expected YYYY-MM-DD HH:MM:SS."


### PR DESCRIPTION
## Summary
- add an authentication helper that issues and validates JWT access tokens using environment-controlled secrets and lifetimes, with a built-in fallback when PyJWT is unavailable
- extend the user model with a role field, secure API routes with role-aware guards, and expose a login endpoint alongside nutritionist/admin-only workflows
- add an Alembic migration plus comprehensive integration tests (and request stub header support) to cover authorized and unauthorized API flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee230cc0e483228bcb65299f4b7ea9