### PR TITLE
Add subscription management flows and webhook handling

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, Integer, String, DateTime, DECIMAL, Text, Boolean, ForeignKey, func
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    DECIMAL,
+    Text,
+    Boolean,
+    ForeignKey,
+    func,
+)
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -27,6 +37,7 @@ class User(Base):
     progress = relationship('UserProgress', back_populates='user')
     diet_plans = relationship('DietPlan', back_populates='user')
     workout_plans = relationship('WorkoutPlan', back_populates='user')
+    subscriptions = relationship('UserSubscription', back_populates='user', cascade='all, delete-orphan')
 
 class UserProgress(Base):
     __tablename__ = 'user_progress'
@@ -88,3 +99,41 @@ class Appointment(Base):
     created_at = Column(DateTime, default=func.now())
     status = Column(String(50), default='scheduled')
     google_calendar_event_id = Column(String(255))
+
+
+class SubscriptionPlan(Base):
+    __tablename__ = 'subscription_plans'
+
+    plan_id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False, unique=True)
+    description = Column(Text)
+    price = Column(DECIMAL(8, 2), nullable=False)
+    billing_interval = Column(String(50), nullable=False)
+    one_on_one_session_limit = Column(Integer, default=0)
+    group_session_limit = Column(Integer, default=0)
+    allow_one_on_one = Column(Boolean, default=False)
+    allow_group_sessions = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    subscriptions = relationship('UserSubscription', back_populates='plan', cascade='all, delete-orphan')
+
+
+class UserSubscription(Base):
+    __tablename__ = 'user_subscriptions'
+
+    subscription_id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.user_id'), nullable=False)
+    plan_id = Column(Integer, ForeignKey('subscription_plans.plan_id'), nullable=False)
+    status = Column(String(50), default='pending', nullable=False)
+    checkout_session_id = Column(String(255), unique=True)
+    external_customer_id = Column(String(255))
+    external_subscription_id = Column(String(255))
+    renewal_date = Column(DateTime)
+    activated_at = Column(DateTime)
+    canceled_at = Column(DateTime)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    user = relationship('User', back_populates='subscriptions')
+    plan = relationship('SubscriptionPlan', back_populates='subscriptions')

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,8 +1,70 @@
-from flask import Blueprint, request, jsonify, render_template
+import json
+import os
+import uuid
+import hmac
+import hashlib
 from datetime import datetime
+
+from flask import Blueprint, request, jsonify, render_template
 from werkzeug.security import generate_password_hash
 from database import SessionLocal
-from models import User, UserProgress, DietPlan, WorkoutPlan, Message, Appointment
+from models import (
+    User,
+    UserProgress,
+    DietPlan,
+    WorkoutPlan,
+    Message,
+    Appointment,
+    SubscriptionPlan,
+    UserSubscription,
+)
+
+
+WEBHOOK_SECRET = os.getenv('PAYMENT_WEBHOOK_SECRET', 'test_secret')
+
+
+class PaymentClient:
+    """Very small abstraction over the external payment provider."""
+
+    def create_checkout_session(self, *, plan: SubscriptionPlan, user: User) -> dict:
+        checkout_id = f"cs_{uuid.uuid4().hex}"
+        return {
+            "id": checkout_id,
+            "url": f"https://payments.example.com/checkout/{checkout_id}",
+        }
+
+    def cancel_subscription(self, *, external_subscription_id: str) -> dict:
+        # In a real implementation the external API would be called here.
+        return {"status": "canceled", "external_subscription_id": external_subscription_id}
+
+
+payment_client = PaymentClient()
+
+
+def _verify_signature(raw_payload: bytes, provided_signature: str | None) -> bool:
+    if not provided_signature:
+        return False
+    expected = hmac.new(WEBHOOK_SECRET.encode("utf-8"), raw_payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, provided_signature)
+
+
+def _serialize_subscription(subscription: UserSubscription | None) -> dict | None:
+    if subscription is None:
+        return None
+    return {
+        "subscription_id": subscription.subscription_id,
+        "status": subscription.status,
+        "plan": {
+            "plan_id": subscription.plan.plan_id,
+            "name": subscription.plan.name,
+        } if subscription.plan else None,
+        "checkout_session_id": subscription.checkout_session_id,
+        "external_subscription_id": subscription.external_subscription_id,
+        "external_customer_id": subscription.external_customer_id,
+        "renewal_date": subscription.renewal_date.isoformat() if subscription.renewal_date else None,
+        "activated_at": subscription.activated_at.isoformat() if subscription.activated_at else None,
+        "canceled_at": subscription.canceled_at.isoformat() if subscription.canceled_at else None,
+    }
 
 bp = Blueprint('api', __name__)
 
@@ -70,6 +132,222 @@ def create_user():
     session.refresh(new_user)
     session.close()
     return jsonify({"message": "User created successfully", "user_id": new_user.user_id}), 201
+
+
+# --------------------------------
+# Subscription Plans Endpoints
+# --------------------------------
+@bp.route('/subscriptions/plans', methods=['GET', 'POST'])
+def manage_subscription_plans():
+    session = SessionLocal()
+    try:
+        if request.method == 'POST':
+            data = request.get_json() or {}
+            try:
+                price = data['price']
+                billing_interval = data['billing_interval']
+                name = data['name']
+            except KeyError as exc:  # pragma: no cover - defensive guard
+                return jsonify({"error": f"Missing required field: {exc.args[0]}"}), 400
+
+            plan = SubscriptionPlan(
+                name=name,
+                description=data.get('description'),
+                price=price,
+                billing_interval=billing_interval,
+                one_on_one_session_limit=data.get('one_on_one_session_limit', 0),
+                group_session_limit=data.get('group_session_limit', 0),
+                allow_one_on_one=data.get('allow_one_on_one', False),
+                allow_group_sessions=data.get('allow_group_sessions', False),
+            )
+            session.add(plan)
+            session.commit()
+            session.refresh(plan)
+            return (
+                jsonify(
+                    {
+                        "plan_id": plan.plan_id,
+                        "name": plan.name,
+                        "billing_interval": plan.billing_interval,
+                    }
+                ),
+                201,
+            )
+
+        plans = session.query(SubscriptionPlan).order_by(SubscriptionPlan.plan_id).all()
+        serialized = []
+        for plan in plans:
+            serialized.append(
+                {
+                    "plan_id": plan.plan_id,
+                    "name": plan.name,
+                    "description": plan.description,
+                    "price": float(plan.price),
+                    "billing_interval": plan.billing_interval,
+                    "one_on_one_session_limit": plan.one_on_one_session_limit,
+                    "group_session_limit": plan.group_session_limit,
+                    "allow_one_on_one": plan.allow_one_on_one,
+                    "allow_group_sessions": plan.allow_group_sessions,
+                }
+            )
+        return jsonify(serialized)
+    finally:
+        session.close()
+
+
+# --------------------------------
+# User Subscription Endpoints
+# --------------------------------
+@bp.route('/users/<int:user_id>/subscription', methods=['GET', 'POST', 'DELETE'])
+def manage_user_subscription(user_id: int):
+    session = SessionLocal()
+    try:
+        user = session.query(User).filter(User.user_id == user_id).first()
+        if user is None:
+            return jsonify({"error": "User not found"}), 404
+
+        latest_subscription = (
+            session.query(UserSubscription)
+            .filter(UserSubscription.user_id == user_id)
+            .order_by(UserSubscription.created_at.desc())
+            .first()
+        )
+
+        if request.method == 'GET':
+            return jsonify(
+                {
+                    "user_id": user.user_id,
+                    "sub_status": user.sub_status,
+                    "subscription_expiry": user.subscription_expiry.isoformat()
+                    if user.subscription_expiry
+                    else None,
+                    "subscription": _serialize_subscription(latest_subscription),
+                }
+            )
+
+        if request.method == 'POST':
+            data = request.get_json() or {}
+            plan_id = data.get('plan_id')
+            if plan_id is None:
+                return jsonify({"error": "plan_id is required"}), 400
+
+            plan = session.query(SubscriptionPlan).filter(SubscriptionPlan.plan_id == plan_id).first()
+            if plan is None:
+                return jsonify({"error": "Subscription plan not found"}), 404
+
+            checkout = payment_client.create_checkout_session(plan=plan, user=user)
+
+            subscription = UserSubscription(
+                user_id=user.user_id,
+                plan_id=plan.plan_id,
+                status='pending',
+                checkout_session_id=checkout['id'],
+            )
+            session.add(subscription)
+            session.commit()
+            session.refresh(subscription)
+
+            return (
+                jsonify(
+                    {
+                        "checkout_session_id": checkout['id'],
+                        "checkout_url": checkout['url'],
+                        "subscription": _serialize_subscription(subscription),
+                    }
+                ),
+                201,
+            )
+
+        # DELETE
+        if latest_subscription is None:
+            return jsonify({"error": "No subscription to cancel"}), 404
+
+        if latest_subscription.external_subscription_id:
+            payment_client.cancel_subscription(
+                external_subscription_id=latest_subscription.external_subscription_id
+            )
+
+        latest_subscription.status = 'canceled'
+        latest_subscription.canceled_at = datetime.utcnow()
+        user.sub_status = False
+        user.subscription_expiry = None
+        session.commit()
+
+        return jsonify({"message": "Subscription canceled"})
+    finally:
+        session.close()
+
+
+# --------------------------------
+# Webhook Endpoint
+# --------------------------------
+@bp.route('/webhooks/payments', methods=['POST'])
+def payment_webhook():
+    raw_payload = request.get_data()
+    signature = request.headers.get('X-Signature')
+
+    if not _verify_signature(raw_payload, signature):
+        return jsonify({"error": "Invalid signature"}), 400
+
+    try:
+        event = json.loads(raw_payload.decode('utf-8'))
+    except json.JSONDecodeError:
+        return jsonify({"error": "Invalid payload"}), 400
+
+    event_type = event.get('type')
+    data = event.get('data', {})
+
+    session = SessionLocal()
+    try:
+        if event_type == 'checkout.session.completed':
+            checkout_id = data.get('checkout_session_id')
+            renewal = data.get('renewal_date')
+            external_subscription_id = data.get('external_subscription_id')
+            external_customer_id = data.get('external_customer_id')
+
+            subscription = (
+                session.query(UserSubscription)
+                .filter(UserSubscription.checkout_session_id == checkout_id)
+                .first()
+            )
+
+            if subscription is None:
+                return jsonify({"error": "Subscription not found"}), 404
+
+            subscription.status = 'active'
+            subscription.external_subscription_id = external_subscription_id
+            subscription.external_customer_id = external_customer_id
+            subscription.activated_at = datetime.utcnow()
+            if renewal:
+                subscription.renewal_date = datetime.fromisoformat(renewal)
+
+            user = session.query(User).filter(User.user_id == subscription.user_id).one()
+            user.sub_status = True
+            user.subscription_expiry = subscription.renewal_date
+            session.commit()
+            return jsonify({"status": "processed"})
+
+        if event_type in {'customer.subscription.deleted', 'subscription.canceled'}:
+            external_subscription_id = data.get('external_subscription_id')
+            subscription = (
+                session.query(UserSubscription)
+                .filter(UserSubscription.external_subscription_id == external_subscription_id)
+                .first()
+            )
+            if subscription is None:
+                return jsonify({"error": "Subscription not found"}), 404
+
+            subscription.status = 'canceled'
+            subscription.canceled_at = datetime.utcnow()
+            user = session.query(User).filter(User.user_id == subscription.user_id).one()
+            user.sub_status = False
+            user.subscription_expiry = None
+            session.commit()
+            return jsonify({"status": "processed"})
+
+        return jsonify({"status": "ignored"})
+    finally:
+        session.close()
 
 # --------------------------------
 # Diet Plans Endpoints

--- a/migrations/001_create_subscription_tables.py
+++ b/migrations/001_create_subscription_tables.py
@@ -1,0 +1,26 @@
+"""Migration script to add subscription related tables."""
+
+from typing import Sequence
+
+from sqlalchemy import Table
+
+from database import engine
+from models import SubscriptionPlan, UserSubscription
+
+
+TABLES: Sequence[Table] = (
+    SubscriptionPlan.__table__,
+    UserSubscription.__table__,
+)
+
+
+def upgrade() -> None:
+    """Create subscription tables if they do not already exist."""
+    for table in TABLES:
+        table.create(bind=engine, checkfirst=True)
+
+
+def downgrade() -> None:
+    """Drop subscription tables."""
+    for table in reversed(TABLES):
+        table.drop(bind=engine, checkfirst=True)

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -1,0 +1,23 @@
+"""Utility helpers for running lightweight migrations in tests or scripts."""
+
+from importlib import import_module
+from pathlib import Path
+from typing import Iterable
+
+from database import engine
+
+
+def available_migrations() -> Iterable[str]:
+    base_path = Path(__file__).parent
+    for file in sorted(base_path.glob("[0-9][0-9][0-9]_*.py")):
+        yield file.stem
+
+
+def run_migrations() -> None:
+    for migration in available_migrations():
+        module = import_module(f"migrations.{migration}")
+        if hasattr(module, "upgrade"):
+            module.upgrade()
+
+
+__all__ = ["available_migrations", "run_migrations", "engine"]

--- a/tests/_requests_stub.py
+++ b/tests/_requests_stub.py
@@ -36,15 +36,18 @@ class Response:
         return json_module.loads(self._body.decode("utf-8"))
 
 
-def _request(method: str, url: str, *, params=None, json=None):
+def _request(method: str, url: str, *, params=None, json=None, data=None, headers=None):
     target = _prepare_url(url, params)
-    data = None
-    headers = {}
+    body_data = data
+    header_map = {"Content-Type": "application/json"} if json is not None else {}
     if json is not None:
-        data = json_module.dumps(json).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    request = Request(target, data=data, method=method.upper())
-    for key, value in headers.items():
+        body_data = json_module.dumps(json).encode("utf-8")
+    if headers:
+        header_map.update(headers)
+    if body_data is not None and isinstance(body_data, str):
+        body_data = body_data.encode("utf-8")
+    request = Request(target, data=body_data, method=method.upper())
+    for key, value in header_map.items():
         request.add_header(key, value)
     try:
         with urlopen(request) as response:  # nosec B310 - only used in tests
@@ -61,10 +64,14 @@ def get(url: str, params=None):
     return _request("GET", url, params=params)
 
 
-def post(url: str, json=None):
-    return _request("POST", url, json=json)
+def post(url: str, json=None, data=None, headers=None):
+    return _request("POST", url, json=json, data=data, headers=headers)
+
+
+def delete(url: str, json=None, data=None, headers=None):
+    return _request("DELETE", url, json=json, data=data, headers=headers)
 
 
 exceptions = SimpleNamespace(ConnectionError=ConnectionError)
 
-__all__ = ["get", "post", "exceptions", "Response", "ConnectionError"]
+__all__ = ["get", "post", "delete", "exceptions", "Response", "ConnectionError"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,6 @@
+import json
+import hmac
+import hashlib
 import time
 from datetime import datetime, timedelta
 
@@ -26,6 +29,22 @@ def create_user(base_url, username, email, **extra):
     data = response.json()
     assert "user_id" in data
     return data["user_id"]
+
+
+def create_plan(base_url, name="Starter", price=49.99, **extra):
+    payload = {
+        "name": name,
+        "price": price,
+        "billing_interval": extra.get("billing_interval", "monthly"),
+        "description": extra.get("description", "Test plan"),
+        "allow_one_on_one": extra.get("allow_one_on_one", True),
+        "allow_group_sessions": extra.get("allow_group_sessions", False),
+        "one_on_one_session_limit": extra.get("one_on_one_session_limit", 2),
+        "group_session_limit": extra.get("group_session_limit", 0),
+    }
+    response = requests.post(f"{base_url}/subscriptions/plans", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()["plan_id"]
 
 
 def test_index_page_loads(base_url):
@@ -131,6 +150,15 @@ def test_diet_plan_creation_and_retrieval(base_url):
     assert plan["end_date"].startswith(end_date.isoformat())
 
 
+def test_subscription_plan_listing(base_url):
+    plan_id = create_plan(base_url)
+
+    response = requests.get(f"{base_url}/subscriptions/plans")
+    assert response.status_code == 200
+    plans = response.json()
+    assert any(plan["plan_id"] == plan_id for plan in plans)
+
+
 def test_diet_plan_creation_with_invalid_dates_returns_400(base_url):
     user_id = create_user(base_url, "dietuser2", "diet2@example.com")
     response = requests.post(
@@ -219,6 +247,144 @@ def test_appointment_workflow(base_url):
     not_found = requests.get(f"{base_url}/appointments/{appointment_id + 1}")
     assert not_found.status_code == 404
     assert not_found.json()["message"] == "Appointment not found"
+
+
+def _webhook_headers(payload: dict[str, object]) -> dict[str, str]:
+    from routes import WEBHOOK_SECRET  # Imported lazily to avoid circular imports
+
+    body = json.dumps(payload)
+    signature = hmac.new(
+        WEBHOOK_SECRET.encode("utf-8"), body.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return {
+        "Content-Type": "application/json",
+        "X-Signature": signature,
+    }
+
+
+def test_subscription_purchase_and_activation_flow(base_url, monkeypatch):
+    plan_id = create_plan(base_url, name="Premium", price=79.0)
+    user_id = create_user(base_url, "subbuyer", "subbuyer@example.com")
+
+    class DummyClient:
+        def __init__(self):
+            self.created = []
+
+        def create_checkout_session(self, *, plan, user):  # pragma: no cover - exercised in test
+            session_id = "cs_test_checkout"
+            self.created.append((plan.plan_id, user.user_id))
+            return {
+                "id": session_id,
+                "url": f"https://example.test/checkout/{session_id}",
+            }
+
+        def cancel_subscription(self, *, external_subscription_id):  # pragma: no cover - not used here
+            return {"status": "canceled"}
+
+    dummy = DummyClient()
+    monkeypatch.setattr("routes.payment_client", dummy)
+
+    purchase = requests.post(
+        f"{base_url}/users/{user_id}/subscription",
+        json={"plan_id": plan_id},
+    )
+    assert purchase.status_code == 201, purchase.text
+    data = purchase.json()
+    assert data["checkout_session_id"] == "cs_test_checkout"
+    assert data["subscription"]["status"] == "pending"
+
+    webhook_payload = {
+        "type": "checkout.session.completed",
+        "data": {
+            "checkout_session_id": "cs_test_checkout",
+            "external_subscription_id": "sub_123",
+            "external_customer_id": "cus_123",
+            "renewal_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+        },
+    }
+
+    webhook_response = requests.post(
+        f"{base_url}/webhooks/payments",
+        data=json.dumps(webhook_payload),
+        headers=_webhook_headers(webhook_payload),
+    )
+    assert webhook_response.status_code == 200, webhook_response.text
+
+    subscription_details = requests.get(f"{base_url}/users/{user_id}/subscription")
+    assert subscription_details.status_code == 200
+    payload = subscription_details.json()
+    assert payload["sub_status"] is True
+    assert payload["subscription"]["status"] == "active"
+    assert payload["subscription"]["external_subscription_id"] == "sub_123"
+
+
+def test_subscription_cancellation_flow(base_url, monkeypatch):
+    plan_id = create_plan(base_url, name="CancelPlan")
+    user_id = create_user(base_url, "canceluser", "cancel@example.com")
+
+    class CancelClient:
+        def __init__(self):
+            self.cancelled = []
+
+        def create_checkout_session(self, *, plan, user):  # pragma: no cover - exercised in test
+            return {
+                "id": "cs_cancel",
+                "url": "https://example.test/checkout/cs_cancel",
+            }
+
+        def cancel_subscription(self, *, external_subscription_id):
+            self.cancelled.append(external_subscription_id)
+            return {"status": "canceled"}
+
+    client = CancelClient()
+    monkeypatch.setattr("routes.payment_client", client)
+
+    purchase = requests.post(
+        f"{base_url}/users/{user_id}/subscription",
+        json={"plan_id": plan_id},
+    )
+    assert purchase.status_code == 201
+
+    # Activate via webhook to set external IDs
+    webhook_payload = {
+        "type": "checkout.session.completed",
+        "data": {
+            "checkout_session_id": "cs_cancel",
+            "external_subscription_id": "sub_cancel",
+            "external_customer_id": "cus_cancel",
+            "renewal_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+        },
+    }
+    requests.post(
+        f"{base_url}/webhooks/payments",
+        data=json.dumps(webhook_payload),
+        headers=_webhook_headers(webhook_payload),
+    )
+
+    cancel_response = requests.delete(f"{base_url}/users/{user_id}/subscription")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["message"] == "Subscription canceled"
+    assert client.cancelled == ["sub_cancel"]
+
+    details = requests.get(f"{base_url}/users/{user_id}/subscription").json()
+    assert details["sub_status"] is False
+    assert details["subscription"]["status"] == "canceled"
+
+
+def test_webhook_signature_verification(base_url):
+    payload = {
+        "type": "checkout.session.completed",
+        "data": {
+            "checkout_session_id": "does-not-exist",
+        },
+    }
+    response = requests.post(
+        f"{base_url}/webhooks/payments",
+        data=json.dumps(payload),
+        headers={"Content-Type": "application/json", "X-Signature": "invalid"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "Invalid signature"
 
 
 def test_create_appointment_with_invalid_datetime_returns_400(base_url):


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and lightweight migrations for subscription plans and user subscriptions
- expose routes to list plans, manage user subscription lifecycle, and process payment webhooks with signature checks
- extend the requests stub and integration tests to cover subscription purchase, cancellation, and webhook validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee2312e3ac8322b250d3c87eedc236