### PR TITLE
Add progress and workout plan endpoints

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,8 +1,271 @@
 from flask import Blueprint, request, jsonify, render_template
 from datetime import datetime
+from typing import Dict, Optional, Tuple
 from werkzeug.security import generate_password_hash
 from database import SessionLocal
 from models import User, UserProgress, DietPlan, WorkoutPlan, Message, Appointment
+
+
+def _iso_datetime(value, field_name, *, default: Optional[datetime] = None) -> Optional[datetime]:
+    """Parse an ISO 8601 datetime (or date) value from the request payload."""
+    if value is None:
+        return default
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            trimmed = value.strip()
+            if len(trimmed) == 10:
+                return datetime.strptime(trimmed, "%Y-%m-%d")
+            return datetime.fromisoformat(trimmed)
+        except ValueError as exc:  # pragma: no cover - defensive: ValueError path tested via API
+            raise ValueError(
+                f"Invalid date format for {field_name}. Expected ISO 8601 string."
+            ) from exc
+    raise ValueError(f"Invalid type for {field_name}. Expected ISO 8601 string.")
+
+
+def _decimal_to_float(value):
+    return float(value) if value is not None else None
+
+
+DEFAULT_PROGRESS_UNITS = {"weight": "kg", "circumference": "cm"}
+WEIGHT_CONVERSIONS = {"kg": 1.0, "lb": 0.45359237}
+CIRCUMFERENCE_CONVERSIONS = {"cm": 1.0, "in": 2.54}
+
+
+def _normalize_unit(unit, measurement_name, conversions, default_unit):
+    if unit is None:
+        return default_unit
+    if not isinstance(unit, str):
+        raise ValueError(f"Invalid {measurement_name}_unit '{unit}'. Allowed units: {', '.join(sorted(conversions))}.")
+    normalized = unit.lower()
+    if normalized not in conversions:
+        allowed = ", ".join(sorted(conversions))
+        raise ValueError(f"Invalid {measurement_name}_unit '{unit}'. Allowed units: {allowed}.")
+    return normalized
+
+
+def _convert_measurement(value, unit, conversions, field_name):
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        readable = field_name.replace("_", " ").capitalize()
+        raise ValueError(f"{readable} must be a number.") from exc
+    return numeric * conversions[unit]
+
+
+def _parse_optional_float(value, field_name):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        readable = field_name.replace("_", " ").capitalize()
+        raise ValueError(f"{readable} must be a number.") from exc
+
+
+def _serialize_progress(progress: UserProgress, units: Optional[Dict[str, str]] = None) -> Dict:
+    payload = {
+        "progress_id": progress.progress_id,
+        "user_id": progress.user_id,
+        "recorded_at": progress.recorded_at.isoformat() if progress.recorded_at else None,
+        "weight": _decimal_to_float(progress.weight),
+        "bmi": _decimal_to_float(progress.bmi),
+        "body_fat_percentage": _decimal_to_float(progress.body_fat_percentage),
+        "neck_circumference": _decimal_to_float(progress.neck_circumference),
+        "abdomen_circumference": _decimal_to_float(progress.abdomen_circumference),
+        "hip_circumference": _decimal_to_float(progress.hip_circumference),
+        "notes": progress.notes,
+    }
+    payload["units"] = units or DEFAULT_PROGRESS_UNITS.copy()
+    return payload
+
+
+def _serialize_workout_plan(plan: WorkoutPlan) -> Dict:
+    return {
+        "workout_id": plan.workout_id,
+        "user_id": plan.user_id,
+        "trainer_id": plan.trainer_id,
+        "start_date": plan.start_date.isoformat() if plan.start_date else None,
+        "end_date": plan.end_date.isoformat() if plan.end_date else None,
+        "workout_details": plan.workout_details,
+        "notes": plan.notes,
+        "created_at": plan.created_at.isoformat() if plan.created_at else None,
+    }
+
+
+def _error_response(message, status_code=400):
+    return jsonify({"error": message}), status_code
+
+
+def _progress_creation_fields(data: Dict) -> Tuple[Dict, Dict[str, str]]:
+    if not isinstance(data, dict):
+        raise ValueError("Invalid JSON payload.")
+
+    fields: Dict = {}
+    recorded_at = _iso_datetime(data.get("recorded_at"), "recorded_at", default=datetime.utcnow())
+    fields["recorded_at"] = recorded_at
+
+    weight_unit = _normalize_unit(
+        data.get("weight_unit"),
+        "weight",
+        WEIGHT_CONVERSIONS,
+        DEFAULT_PROGRESS_UNITS["weight"],
+    )
+    weight_value = _convert_measurement(
+        data.get("weight"), weight_unit, WEIGHT_CONVERSIONS, "weight"
+    )
+    if weight_value is not None:
+        fields["weight"] = weight_value
+
+    bmi_value = _parse_optional_float(data.get("bmi"), "bmi")
+    if bmi_value is not None:
+        fields["bmi"] = bmi_value
+
+    body_fat_value = _parse_optional_float(
+        data.get("body_fat_percentage"), "body_fat_percentage"
+    )
+    if body_fat_value is not None:
+        if not 0 <= body_fat_value <= 100:
+            raise ValueError("body_fat_percentage must be between 0 and 100.")
+        fields["body_fat_percentage"] = body_fat_value
+
+    circumference_unit = _normalize_unit(
+        data.get("circumference_unit"),
+        "circumference",
+        CIRCUMFERENCE_CONVERSIONS,
+        DEFAULT_PROGRESS_UNITS["circumference"],
+    )
+    for field in ("neck_circumference", "abdomen_circumference", "hip_circumference"):
+        value = data.get(field)
+        if value is not None:
+            fields[field] = _convert_measurement(
+                value, circumference_unit, CIRCUMFERENCE_CONVERSIONS, field
+            )
+
+    if "notes" in data:
+        fields["notes"] = data.get("notes")
+
+    units = DEFAULT_PROGRESS_UNITS.copy()
+    return fields, units
+
+
+def _apply_progress_update(progress: UserProgress, data: Dict) -> Dict[str, str]:
+    if not isinstance(data, dict):
+        raise ValueError("Invalid JSON payload.")
+
+    units = DEFAULT_PROGRESS_UNITS.copy()
+
+    if "recorded_at" in data:
+        progress.recorded_at = _iso_datetime(data.get("recorded_at"), "recorded_at")
+
+    if "notes" in data:
+        progress.notes = data.get("notes")
+
+    if "bmi" in data:
+        progress.bmi = _parse_optional_float(data.get("bmi"), "bmi")
+
+    if "body_fat_percentage" in data:
+        body_fat_value = _parse_optional_float(
+            data.get("body_fat_percentage"), "body_fat_percentage"
+        )
+        if body_fat_value is not None and not 0 <= body_fat_value <= 100:
+            raise ValueError("body_fat_percentage must be between 0 and 100.")
+        progress.body_fat_percentage = body_fat_value
+
+    if "weight" in data or "weight_unit" in data:
+        if "weight" not in data:
+            raise ValueError("weight must be provided when specifying weight_unit.")
+        weight_unit = _normalize_unit(
+            data.get("weight_unit"),
+            "weight",
+            WEIGHT_CONVERSIONS,
+            DEFAULT_PROGRESS_UNITS["weight"],
+        )
+        progress.weight = _convert_measurement(
+            data.get("weight"), weight_unit, WEIGHT_CONVERSIONS, "weight"
+        )
+
+    circumference_fields = [
+        field
+        for field in ("neck_circumference", "abdomen_circumference", "hip_circumference")
+        if field in data
+    ]
+    if "circumference_unit" in data and not circumference_fields:
+        _normalize_unit(
+            data.get("circumference_unit"),
+            "circumference",
+            CIRCUMFERENCE_CONVERSIONS,
+            DEFAULT_PROGRESS_UNITS["circumference"],
+        )
+    if circumference_fields:
+        circumference_unit = _normalize_unit(
+            data.get("circumference_unit"),
+            "circumference",
+            CIRCUMFERENCE_CONVERSIONS,
+            DEFAULT_PROGRESS_UNITS["circumference"],
+        )
+        for field in circumference_fields:
+            setattr(
+                progress,
+                field,
+                _convert_measurement(
+                    data.get(field), circumference_unit, CIRCUMFERENCE_CONVERSIONS, field
+                ),
+            )
+
+    return units
+
+
+def _workout_fields_from_payload(
+    data: Dict, *, partial: bool = False, existing_plan: Optional[WorkoutPlan] = None
+) -> Dict:
+    if not isinstance(data, dict):
+        raise ValueError("Invalid JSON payload.")
+
+    fields: Dict = {}
+    start_reference = existing_plan.start_date if existing_plan else None
+    end_reference = existing_plan.end_date if existing_plan else None
+
+    if partial:
+        if "start_date" in data:
+            start_reference = _iso_datetime(data.get("start_date"), "start_date")
+            fields["start_date"] = start_reference
+        if "end_date" in data:
+            end_reference = _iso_datetime(data.get("end_date"), "end_date")
+            fields["end_date"] = end_reference
+    else:
+        start_reference = _iso_datetime(data.get("start_date"), "start_date")
+        end_reference = _iso_datetime(data.get("end_date"), "end_date")
+        if start_reference is None or end_reference is None:
+            raise ValueError("start_date and end_date are required.")
+        fields["start_date"] = start_reference
+        fields["end_date"] = end_reference
+
+    if start_reference and end_reference and end_reference < start_reference:
+        raise ValueError("end_date cannot be earlier than start_date.")
+
+    if not partial:
+        details = data.get("workout_details")
+        if not details:
+            raise ValueError("workout_details is required.")
+        fields["workout_details"] = details
+    elif "workout_details" in data:
+        details = data.get("workout_details")
+        if details is None or details == "":
+            raise ValueError("workout_details cannot be empty.")
+        fields["workout_details"] = details
+
+    if "trainer_id" in data:
+        fields["trainer_id"] = data.get("trainer_id")
+
+    if "notes" in data:
+        fields["notes"] = data.get("notes")
+
+    return fields
 
 bp = Blueprint('api', __name__)
 
@@ -115,6 +378,161 @@ def create_diet_plan(user_id):
         session.commit()
         session.refresh(new_diet_plan)
         return jsonify({"message": "Diet plan created successfully", "diet_id": new_diet_plan.diet_id}), 201
+    finally:
+        session.close()
+
+# --------------------------------
+# User Progress Endpoints
+# --------------------------------
+@bp.route('/users/<int:user_id>/progress', methods=['GET', 'POST', 'PATCH'])
+def manage_user_progress(user_id):
+    session = SessionLocal()
+    try:
+        if request.method == 'GET':
+            entries = (
+                session.query(UserProgress)
+                .filter(UserProgress.user_id == user_id)
+                .order_by(UserProgress.recorded_at.asc(), UserProgress.progress_id.asc())
+                .all()
+            )
+            return jsonify([_serialize_progress(entry) for entry in entries])
+
+        data = request.get_json() or {}
+        if not isinstance(data, dict):
+            return _error_response("Invalid JSON payload.")
+
+        if request.method == 'POST':
+            try:
+                fields, units = _progress_creation_fields(data)
+            except ValueError as exc:
+                session.rollback()
+                return _error_response(str(exc))
+
+            new_progress = UserProgress(user_id=user_id, **fields)
+            session.add(new_progress)
+            session.commit()
+            session.refresh(new_progress)
+            return (
+                jsonify(
+                    {
+                        "message": "Progress entry recorded successfully",
+                        "progress": _serialize_progress(new_progress, units),
+                    }
+                ),
+                201,
+            )
+
+        progress_id = data.get('progress_id')
+        if not progress_id:
+            return _error_response("progress_id is required for updates.")
+
+        progress = (
+            session.query(UserProgress)
+            .filter(
+                UserProgress.user_id == user_id,
+                UserProgress.progress_id == progress_id,
+            )
+            .first()
+        )
+        if not progress:
+            return _error_response("Progress entry not found", status_code=404)
+
+        try:
+            units = _apply_progress_update(progress, data)
+        except ValueError as exc:
+            session.rollback()
+            return _error_response(str(exc))
+
+        session.commit()
+        session.refresh(progress)
+        return (
+            jsonify(
+                {
+                    "message": "Progress entry updated successfully",
+                    "progress": _serialize_progress(progress, units),
+                }
+            ),
+            200,
+        )
+    finally:
+        session.close()
+
+# --------------------------------
+# Workout Plan Endpoints
+# --------------------------------
+@bp.route('/users/<int:user_id>/workout_plans', methods=['GET', 'POST', 'PATCH'])
+def manage_workout_plans(user_id):
+    session = SessionLocal()
+    try:
+        if request.method == 'GET':
+            plans = (
+                session.query(WorkoutPlan)
+                .filter(WorkoutPlan.user_id == user_id)
+                .order_by(WorkoutPlan.start_date.asc(), WorkoutPlan.workout_id.asc())
+                .all()
+            )
+            return jsonify([_serialize_workout_plan(plan) for plan in plans])
+
+        data = request.get_json() or {}
+        if not isinstance(data, dict):
+            return _error_response("Invalid JSON payload.")
+
+        if request.method == 'POST':
+            try:
+                fields = _workout_fields_from_payload(data)
+            except ValueError as exc:
+                session.rollback()
+                return _error_response(str(exc))
+
+            workout_plan = WorkoutPlan(user_id=user_id, **fields)
+            session.add(workout_plan)
+            session.commit()
+            session.refresh(workout_plan)
+            return (
+                jsonify(
+                    {
+                        "message": "Workout plan created successfully",
+                        "workout_plan": _serialize_workout_plan(workout_plan),
+                    }
+                ),
+                201,
+            )
+
+        workout_id = data.get('workout_id')
+        if not workout_id:
+            return _error_response("workout_id is required for updates.")
+
+        plan = (
+            session.query(WorkoutPlan)
+            .filter(
+                WorkoutPlan.user_id == user_id,
+                WorkoutPlan.workout_id == workout_id,
+            )
+            .first()
+        )
+        if not plan:
+            return _error_response("Workout plan not found", status_code=404)
+
+        try:
+            updates = _workout_fields_from_payload(data, partial=True, existing_plan=plan)
+        except ValueError as exc:
+            session.rollback()
+            return _error_response(str(exc))
+
+        for key, value in updates.items():
+            setattr(plan, key, value)
+
+        session.commit()
+        session.refresh(plan)
+        return (
+            jsonify(
+                {
+                    "message": "Workout plan updated successfully",
+                    "workout_plan": _serialize_workout_plan(plan),
+                }
+            ),
+            200,
+        )
     finally:
         session.close()
 

--- a/tests/_requests_stub.py
+++ b/tests/_requests_stub.py
@@ -65,6 +65,10 @@ def post(url: str, json=None):
     return _request("POST", url, json=json)
 
 
+def patch(url: str, json=None):
+    return _request("PATCH", url, json=json)
+
+
 exceptions = SimpleNamespace(ConnectionError=ConnectionError)
 
-__all__ = ["get", "post", "exceptions", "Response", "ConnectionError"]
+__all__ = ["get", "post", "patch", "exceptions", "Response", "ConnectionError"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timedelta
 
+import pytest
 from werkzeug.security import generate_password_hash
 
 try:  # pragma: no cover - exercised when requests is available
@@ -144,6 +145,99 @@ def test_diet_plan_creation_with_invalid_dates_returns_400(base_url):
     )
     assert response.status_code == 400
     assert response.json()["error"] == "Invalid date format. Expected YYYY-MM-DD."
+
+
+def test_progress_entry_creation_and_history(base_url):
+    user_id = create_user(base_url, "progressuser", "progress@example.com")
+
+    recorded_at = datetime.utcnow().replace(microsecond=0)
+    payload = {
+        "recorded_at": recorded_at.isoformat(),
+        "weight": 180,
+        "weight_unit": "lb",
+        "neck_circumference": 16,
+        "circumference_unit": "in",
+        "body_fat_percentage": 18.5,
+        "notes": "Felt energized",
+    }
+
+    response = requests.post(f"{base_url}/users/{user_id}/progress", json=payload)
+    assert response.status_code == 201
+    created = response.json()["progress"]
+    assert created["progress_id"] > 0
+    assert created["units"] == {"weight": "kg", "circumference": "cm"}
+    assert created["recorded_at"].startswith(recorded_at.isoformat())
+    assert created["weight"] == pytest.approx(81.6466, rel=1e-3)
+    assert created["neck_circumference"] == pytest.approx(40.64, rel=1e-3)
+    assert created["body_fat_percentage"] == pytest.approx(18.5)
+
+    history_response = requests.get(f"{base_url}/users/{user_id}/progress")
+    assert history_response.status_code == 200
+    history = history_response.json()
+    assert len(history) == 1
+    history_entry = history[0]
+    assert history_entry["progress_id"] == created["progress_id"]
+    assert history_entry["units"] == {"weight": "kg", "circumference": "cm"}
+    assert history_entry["weight"] == pytest.approx(created["weight"], rel=1e-9)
+
+
+def test_progress_entry_rejects_invalid_units(base_url):
+    user_id = create_user(base_url, "invalidunits", "invalidunits@example.com")
+
+    response = requests.post(
+        f"{base_url}/users/{user_id}/progress",
+        json={
+            "weight": 70,
+            "weight_unit": "stone",
+        },
+    )
+    assert response.status_code == 400
+    assert "Invalid weight_unit" in response.json()["error"]
+
+
+def test_workout_plan_creation_and_update(base_url):
+    user_id = create_user(base_url, "workoutuser", "workout@example.com")
+
+    start_date = datetime.utcnow().date()
+    end_date = start_date + timedelta(days=14)
+    response = requests.post(
+        f"{base_url}/users/{user_id}/workout_plans",
+        json={
+            "trainer_id": 7,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "workout_details": "Strength training 3x per week",
+            "notes": "Focus on recovery",
+        },
+    )
+    assert response.status_code == 201
+    created_plan = response.json()["workout_plan"]
+    workout_id = created_plan["workout_id"]
+
+    list_response = requests.get(f"{base_url}/users/{user_id}/workout_plans")
+    assert list_response.status_code == 200
+    plans = list_response.json()
+    assert len(plans) == 1
+    assert plans[0]["workout_id"] == workout_id
+
+    updated_end = end_date + timedelta(days=7)
+    patch_response = requests.patch(
+        f"{base_url}/users/{user_id}/workout_plans",
+        json={
+            "workout_id": workout_id,
+            "end_date": updated_end.isoformat(),
+            "notes": "Add light cardio warm-ups",
+        },
+    )
+    assert patch_response.status_code == 200
+    updated_plan = patch_response.json()["workout_plan"]
+    assert updated_plan["notes"] == "Add light cardio warm-ups"
+    assert updated_plan["end_date"].startswith(updated_end.isoformat())
+
+    refreshed_list = requests.get(f"{base_url}/users/{user_id}/workout_plans")
+    assert refreshed_list.status_code == 200
+    refreshed_plan = refreshed_list.json()[0]
+    assert refreshed_plan["notes"] == "Add light cardio warm-ups"
 
 
 def test_message_conversation_flow(base_url):


### PR DESCRIPTION
## Summary
- add helper utilities for parsing/serializing progress and workout plans and expose GET/POST/PATCH handlers
- validate measurement units and date ranges when clients log progress or nutritionists assign workouts
- cover the new routes with tests for creation, history retrieval, and updates while extending the requests stub with PATCH support

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee2317e3408322bb3c254ec2da372c