### PR TITLE
feat: scaffold expo and next turborepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Node
 node_modules/
-pnpm-lock.yaml
 .next/
 dist/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Node
+node_modules/
+pnpm-lock.yaml
+.next/
+dist/
+build/
+.expo/
+.expo-shared/
+
+# Expo
+apps/mobile/.expo/
+apps/mobile/.expo-shared/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.production.local
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+.python-version
+.mypy_cache/
+.pytest_cache/
+
+# Coverage
+coverage/
+htmlcov/

--- a/apps/mobile/.eslintrc.cjs
+++ b/apps/mobile/.eslintrc.cjs
@@ -1,0 +1,39 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.json',
+    ecmaVersion: 2021,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  env: {
+    es2021: true,
+    browser: true,
+    'react-native/react-native': true,
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'react-native'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:react-native/recommended',
+    'prettier',
+  ],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react-native/no-inline-styles': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+  ignorePatterns: ['node_modules/', 'dist/', 'build/'],
+};

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,22 @@
+# Diet Mobile App
+
+This Expo Router application consumes shared UI and theme packages from the Turborepo workspace. Tailwind tokens are provided by `@diet/theme` and utility classes are powered by NativeWind.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev --filter mobile
+```
+
+### Launch targets
+
+- **iOS Simulator**: `pnpm --filter mobile exec expo start --ios`
+- **Android Emulator**: `pnpm --filter mobile exec expo start --android`
+- **Web preview**: `pnpm --filter mobile exec expo start --web`
+
+## Useful scripts
+
+- `pnpm --filter mobile lint` – run ESLint over the Expo app
+- `pnpm --filter mobile test` – execute Jest tests
+- `pnpm --filter mobile build` – create a static web bundle via `expo export`

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,35 @@
+{
+  "expo": {
+    "name": "Diet Mobile",
+    "slug": "diet-mobile",
+    "scheme": "dietmobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#030712"
+    },
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#030712"
+      }
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static",
+      "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "router": {
+        "origin": "auto"
+      }
+    }
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,24 @@
+import { View, Text } from 'react-native';
+import { AppShell } from '@diet/ui';
+import { themeTokens } from '@diet/theme';
+
+const NAV_ITEMS = [
+  { key: 'home', label: 'Home' },
+  { key: 'meals', label: 'Meals' },
+  { key: 'progress', label: 'Progress' }
+];
+
+export default function Index() {
+  return (
+    <AppShell navigationItems={NAV_ITEMS} activeKey="home" title="Dashboard">
+      <View>
+        <Text style={{ color: themeTokens.colors.text, fontSize: 18, fontWeight: '600' }}>
+          Welcome to the neon-fueled nutrition tracker.
+        </Text>
+        <Text style={{ color: themeTokens.colors.muted, fontSize: 14, marginTop: 12 }}>
+          Start logging meals to see tailored macro insights ripple through your day.
+        </Text>
+      </View>
+    </AppShell>
+  );
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel']
+  };
+};

--- a/apps/mobile/expo-env.d.ts
+++ b/apps/mobile/expo-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="expo-router/types" />
+/// <reference types="nativewind/types" />

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!(expo(nent)?|@expo|react-native|@react-native|@react-navigation|nativewind)/)'
+  ]
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "mobile",
+  "version": "0.0.1",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "dev": "expo start --clear",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "jest",
+    "build": "expo export"
+  },
+  "dependencies": {
+    "@diet/theme": "workspace:*",
+    "@diet/ui": "workspace:*",
+    "expo": "~50.0.0",
+    "expo-linear-gradient": "^12.7.2",
+    "expo-router": "~3.4.0",
+    "nativewind": "^2.0.11",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.73.4",
+    "react-native-gesture-handler": "~2.14.0",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-svg": "15.2.0",
+    "react-native-web": "~0.19.10",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.3.3"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.21",
+    "@types/react-native": "0.73.0",
+    "@types/react-test-renderer": "18.0.0",
+    "eslint": "^8.56.0",
+    "jest": "^29.7.0",
+    "jest-expo": "^50.0.2",
+    "react-test-renderer": "18.2.0"
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,9 +27,15 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
     "@types/react": "18.2.21",
     "@types/react-native": "0.73.0",
     "@types/react-test-renderer": "18.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-native": "^4.0.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "jest-expo": "^50.0.2",

--- a/apps/mobile/tailwind.config.ts
+++ b/apps/mobile/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+import { tailwindTheme } from '@diet/theme';
+
+const config: Config = {
+  content: ['./app/**/*.{js,jsx,ts,tsx}', '../../packages/ui/src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: tailwindTheme.colors,
+      blur: tailwindTheme.extend.blur,
+      boxShadow: tailwindTheme.extend.boxShadow
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-native",
+    "types": ["nativewind/types", "expo-router/types"]
+  },
+  "include": ["app", "expo-env.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,22 @@
+# Diet Web App
+
+Next.js 14 is configured with the `@expo/next-adapter` so it can consume Expo SDK packages and share UI primitives with the mobile application. Tailwind consumes the shared theme tokens for neon-ready design primitives.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev --filter web
+```
+
+### Launch commands
+
+- **Development**: `pnpm --filter web dev`
+- **Production build**: `pnpm --filter web build && pnpm --filter web start`
+- **Static export**: `pnpm --filter web exec next export`
+
+## Useful scripts
+
+- `pnpm --filter web lint` – run ESLint with Next.js defaults
+- `pnpm --filter web test` – execute Vitest suites
+- `pnpm --filter web build` – compile the Next.js production bundle

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  background-color: #030712;
+  color: #f8fafc;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Neon Diet Dashboard',
+  description: 'Shared Expo/Next monorepo powered by Turborepo'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { AppShell } from '@diet/ui';
+import { themeTokens } from '@diet/theme';
+import { View, Text } from 'react-native';
+
+const NAV_ITEMS = [
+  { key: 'dashboard', label: 'Dashboard' },
+  { key: 'recipes', label: 'Recipes' },
+  { key: 'community', label: 'Community' }
+];
+
+export default function Page() {
+  return (
+    <View style={{ flex: 1 }}>
+      <AppShell navigationItems={NAV_ITEMS} activeKey="dashboard" title="Analytics">
+        <View>
+          <Text style={{ color: themeTokens.colors.text, fontSize: 24, fontWeight: '700' }}>Today&apos;s Intake</Text>
+          <Text style={{ color: themeTokens.colors.muted, maxWidth: 540, marginTop: 16 }}>
+            Track macros, hydration, and recovery trends with a consistent neon aesthetic across mobile and web.
+          </Text>
+        </View>
+      </AppShell>
+    </View>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,8 @@
+const { withExpo } = require('@expo/next-adapter');
+
+const nextConfig = withExpo({
+  reactStrictMode: true,
+  transpilePackages: ['@diet/ui', '@diet/theme']
+});
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "web",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "lint": "next lint",
+    "test": "vitest",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@diet/theme": "workspace:*",
+    "@diet/ui": "workspace:*",
+    "@expo/next-adapter": "^5.0.0",
+    "framer-motion": "^11.0.0",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.24",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.3.3",
+    "vitest": "^1.4.0"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+import { tailwindTheme } from '@diet/theme';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', '../../packages/ui/src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: tailwindTheme.colors,
+      blur: tailwindTheme.extend.blur,
+      boxShadow: tailwindTheme.extend.boxShadow
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "allowJs": true,
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../../packages/ui/src/**/*.ts", "../../packages/ui/src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "diet-app-monorepo",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "build": "turbo run build"
+  },
+  "devDependencies": {
+    "turbo": "^1.13.4"
+  }
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@diet/theme",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "echo 'No tests for @diet/theme yet'"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,0 +1,23 @@
+import { blurRadii, depthEffects, neonPalette, themeTokens } from './tokens';
+
+export * from './tokens';
+
+export const tailwindTheme = {
+  colors: {
+    background: themeTokens.colors.background,
+    surface: themeTokens.colors.surface,
+    muted: themeTokens.colors.muted,
+    text: themeTokens.colors.text,
+    ...Object.fromEntries(
+      Object.entries(neonPalette).map(([key, value]) => [`neon-${key}`, value])
+    )
+  },
+  extend: {
+    blur: blurRadii,
+    boxShadow: {
+      ...Object.fromEntries(
+        Object.entries(depthEffects).map(([key, value]) => [`neon-${key}`, value])
+      )
+    }
+  }
+};

--- a/packages/theme/src/tokens.ts
+++ b/packages/theme/src/tokens.ts
@@ -1,0 +1,35 @@
+export const neonPalette = {
+  pink: '#ff49db',
+  blue: '#00f6ff',
+  green: '#39ff14',
+  purple: '#7d5bff',
+  yellow: '#f7ff00'
+} as const;
+
+export const blurRadii = {
+  xs: '4px',
+  sm: '8px',
+  md: '16px',
+  lg: '32px',
+  xl: '48px'
+} as const;
+
+export const depthEffects = {
+  soft: '0 10px 30px rgba(0, 246, 255, 0.15)',
+  medium: '0 20px 45px rgba(61, 255, 184, 0.2)',
+  intense: '0 30px 75px rgba(255, 73, 219, 0.35)'
+} as const;
+
+export const themeTokens = {
+  colors: {
+    background: '#030712',
+    surface: '#0b1220',
+    muted: '#6b7280',
+    text: '#f8fafc',
+    neon: neonPalette
+  },
+  blur: blurRadii,
+  depth: depthEffects
+};
+
+export type ThemeTokens = typeof themeTokens;

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@diet/ui",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "echo 'No tests for @diet/ui yet'"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-native": "*"
+  },
+  "dependencies": {
+    "@diet/theme": "workspace:*",
+    "framer-motion": "^11.0.0",
+    "expo-linear-gradient": "^12.7.2"
+  }
+}

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -1,0 +1,229 @@
+import { ReactNode, useMemo } from 'react';
+import { Platform, Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { themeTokens } from '@diet/theme';
+import { AnimatedGradientBackground } from '../motion/GradientBackground';
+
+type NavigationItem = {
+  key: string;
+  label: string;
+  icon?: ReactNode;
+  onPress?: () => void;
+};
+
+type AppShellProps = {
+  navigationItems: NavigationItem[];
+  activeKey?: string;
+  title?: string;
+  children: ReactNode;
+  gradientColors?: string[];
+};
+
+const MOBILE_MAX_WIDTH = 900;
+
+export const AppShell = ({
+  navigationItems,
+  activeKey,
+  title,
+  children,
+  gradientColors = [themeTokens.colors.neon.blue, themeTokens.colors.neon.purple]
+}: AppShellProps) => {
+  const { width } = useWindowDimensions();
+  const isMobile = width <= MOBILE_MAX_WIDTH;
+
+  const gradientStops = useMemo(() => gradientColors, [gradientColors]);
+
+  return (
+    <View style={styles.root}>
+      <AnimatedGradientBackground colors={gradientStops} />
+      <View style={styles.contentWrapper}>
+        {isMobile ? (
+          <MobileLayout navigationItems={navigationItems} activeKey={activeKey} title={title}>
+            {children}
+          </MobileLayout>
+        ) : (
+          <WebLayout navigationItems={navigationItems} activeKey={activeKey} title={title}>
+            {children}
+          </WebLayout>
+        )}
+      </View>
+    </View>
+  );
+};
+
+type LayoutProps = {
+  navigationItems: NavigationItem[];
+  activeKey?: string;
+  title?: string;
+  children: ReactNode;
+};
+
+const MobileLayout = ({ navigationItems, activeKey, title, children }: LayoutProps) => (
+  <View style={styles.mobileContainer}>
+    <View style={styles.page}>{title ? <Text style={styles.pageTitle}>{title}</Text> : null}{children}</View>
+    <View style={styles.mobileNav}>
+      {navigationItems.map((item) => (
+        <Pressable
+          key={item.key}
+          onPress={item.onPress}
+          style={[styles.mobileNavItem, activeKey === item.key && styles.mobileNavItemActive]}
+        >
+          {item.icon}
+          <Text style={[styles.mobileNavLabel, activeKey === item.key && styles.mobileNavLabelActive]}>
+            {item.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  </View>
+);
+
+const WebLayout = ({ navigationItems, activeKey, title, children }: LayoutProps) => (
+  <View style={styles.webContainer}>
+    <View style={styles.sidebar}>
+      <Text style={styles.brand}>NeonDiet</Text>
+      {navigationItems.map((item) => (
+        <Pressable key={item.key} onPress={item.onPress} style={styles.sidebarItem}>
+          <View
+            style={[
+              styles.sidebarPill,
+              activeKey === item.key && {
+                backgroundColor: 'rgba(0, 246, 255, 0.18)',
+                shadowColor: themeTokens.colors.neon.blue,
+                shadowOffset: { width: 0, height: 12 },
+                shadowOpacity: 0.7,
+                shadowRadius: 24,
+                ...(Platform.OS === 'web'
+                  ? { boxShadow: themeTokens.depth.intense }
+                  : {})
+              }
+            ]}
+          >
+            <Text style={[styles.sidebarLabel, activeKey === item.key && styles.sidebarLabelActive]}>
+              {item.label}
+            </Text>
+          </View>
+        </Pressable>
+      ))}
+    </View>
+    <View style={styles.webMain}>
+      <View style={styles.topBar}>
+        {title ? <Text style={styles.topBarTitle}>{title}</Text> : <View />}
+        <View style={styles.topBarActions}>{/* placeholder for actions */}</View>
+      </View>
+      <View style={styles.page}>{children}</View>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: themeTokens.colors.background,
+    position: 'relative',
+    overflow: 'hidden'
+  },
+  contentWrapper: {
+    flex: 1,
+    paddingTop: Platform.OS === 'web' ? 24 : 0,
+    zIndex: 1
+  },
+  page: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 32,
+    paddingBottom: Platform.OS === 'web' ? 32 : 120
+  },
+  pageTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: themeTokens.colors.text,
+    marginBottom: 24
+  },
+  mobileContainer: {
+    flex: 1
+  },
+  mobileNav: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    backgroundColor: 'rgba(3, 7, 18, 0.85)',
+    borderTopWidth: Platform.OS === 'web' ? 1 : 0,
+    borderColor: 'rgba(148, 163, 184, 0.15)',
+    ...(Platform.OS === 'web' ? { backdropFilter: 'blur(12px)' } : {})
+  },
+  mobileNavItem: {
+    alignItems: 'center'
+  },
+  mobileNavItemActive: {
+    transform: [{ translateY: -4 }]
+  },
+  mobileNavLabel: {
+    color: themeTokens.colors.muted,
+    fontSize: 12,
+    marginTop: 4
+  },
+  mobileNavLabelActive: {
+    color: themeTokens.colors.neon.blue
+  },
+  webContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    paddingHorizontal: 32
+  },
+  sidebar: {
+    width: 220,
+    paddingVertical: 48,
+    marginRight: 24
+  },
+  brand: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: themeTokens.colors.neon.pink,
+    marginBottom: 32
+  },
+  sidebarItem: {
+    borderRadius: 20,
+    marginBottom: 16
+  },
+  sidebarPill: {
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    borderRadius: 20,
+    backgroundColor: 'rgba(11, 18, 32, 0.65)'
+  },
+  sidebarLabel: {
+    color: themeTokens.colors.muted,
+    fontSize: 16,
+    fontWeight: '500'
+  },
+  sidebarLabelActive: {
+    color: themeTokens.colors.text
+  },
+  webMain: {
+    flex: 1,
+    borderRadius: 24,
+    backgroundColor: 'rgba(11, 18, 32, 0.92)',
+    padding: 32,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 40 },
+    shadowOpacity: 0.35,
+    shadowRadius: 60
+  },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 24
+  },
+  topBarTitle: {
+    fontSize: 30,
+    fontWeight: '700',
+    color: themeTokens.colors.text
+  },
+  topBarActions: {
+    flexDirection: 'row'
+  }
+});
+
+export type { AppShellProps, NavigationItem };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,2 @@
+export * from './components/AppShell';
+export * from './motion/GradientBackground';

--- a/packages/ui/src/motion/GradientBackground.tsx
+++ b/packages/ui/src/motion/GradientBackground.tsx
@@ -1,0 +1,13 @@
+import { Platform } from 'react-native';
+import { GradientComponent as NativeGradient, GradientProps } from './createGradientComponent.native';
+import { GradientComponent as WebGradient } from './createGradientComponent.web';
+
+export type { GradientProps };
+
+export const AnimatedGradientBackground = (props: GradientProps) => {
+  if (Platform.OS === 'web') {
+    return <WebGradient {...props} />;
+  }
+
+  return <NativeGradient {...props} />;
+};

--- a/packages/ui/src/motion/createGradientComponent.native.tsx
+++ b/packages/ui/src/motion/createGradientComponent.native.tsx
@@ -1,0 +1,10 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { StyleSheet } from 'react-native';
+
+export type GradientProps = {
+  colors: string[];
+};
+
+export const GradientComponent = ({ colors }: GradientProps) => {
+  return <LinearGradient colors={colors} style={StyleSheet.absoluteFill} start={[0, 0]} end={[1, 1]} pointerEvents="none" />;
+};

--- a/packages/ui/src/motion/createGradientComponent.web.tsx
+++ b/packages/ui/src/motion/createGradientComponent.web.tsx
@@ -1,0 +1,21 @@
+import { motion } from 'framer-motion';
+
+export type GradientProps = {
+  colors: string[];
+};
+
+export const GradientComponent = ({ colors }: GradientProps) => (
+  <motion.div
+    aria-hidden
+    initial={{ opacity: 0, scale: 0.95 }}
+    animate={{ opacity: 0.7, scale: 1 }}
+    transition={{ duration: 1.2, ease: 'easeInOut' }}
+    style={{
+      position: 'absolute',
+      inset: 0,
+      pointerEvents: 'none',
+      background: `radial-gradient(circle at 20% 20%, ${colors[0]}40, transparent 60%), radial-gradient(circle at 80% 30%, ${colors[1] ?? colors[0]}55, transparent 70%)`,
+      filter: 'blur(80px)'
+    }}
+  />
+);

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "types": ["react", "react-native"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,117 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    specifiers:
+      turbo: ^1.13.4
+    devDependencies:
+      turbo: ^1.13.4
+
+  apps/mobile:
+    specifiers:
+      '@diet/theme': workspace:*
+      '@diet/ui': workspace:*
+      '@types/react': 18.2.21
+      '@types/react-native': 0.73.0
+      '@types/react-test-renderer': 18.0.0
+      expo: ~50.0.0
+      expo-linear-gradient: ^12.7.2
+      expo-router: ~3.4.0
+      eslint: ^8.56.0
+      jest: ^29.7.0
+      jest-expo: ^50.0.2
+      nativewind: ^2.0.11
+      react: 18.2.0
+      react-dom: 18.2.0
+      react-native: 0.73.4
+      react-native-gesture-handler: ~2.14.0
+      react-native-safe-area-context: 4.8.2
+      react-native-svg: 15.2.0
+      react-native-web: ~0.19.10
+      react-test-renderer: 18.2.0
+      tailwindcss: ^3.4.3
+      typescript: ^5.3.3
+    dependencies:
+      '@diet/theme': workspace:*
+      '@diet/ui': workspace:*
+      expo: ~50.0.0
+      expo-linear-gradient: ^12.7.2
+      expo-router: ~3.4.0
+      nativewind: ^2.0.11
+      react: 18.2.0
+      react-dom: 18.2.0
+      react-native: 0.73.4
+      react-native-gesture-handler: ~2.14.0
+      react-native-safe-area-context: 4.8.2
+      react-native-svg: 15.2.0
+      react-native-web: ~0.19.10
+      tailwindcss: ^3.4.3
+      typescript: ^5.3.3
+    devDependencies:
+      '@types/react': 18.2.21
+      '@types/react-native': 0.73.0
+      '@types/react-test-renderer': 18.0.0
+      eslint: ^8.56.0
+      jest: ^29.7.0
+      jest-expo: ^50.0.2
+      react-test-renderer: 18.2.0
+
+  apps/web:
+    specifiers:
+      '@diet/theme': workspace:*
+      '@diet/ui': workspace:*
+      '@expo/next-adapter': ^5.0.0
+      '@types/node': 20.11.24
+      '@types/react': 18.2.21
+      '@types/react-dom': 18.2.7
+      autoprefixer: ^10.4.16
+      eslint: ^8.56.0
+      eslint-config-next: 14.2.3
+      framer-motion: ^11.0.0
+      next: 14.2.3
+      postcss: ^8.4.33
+      react: 18.2.0
+      react-dom: 18.2.0
+      tailwindcss: ^3.4.3
+      typescript: ^5.3.3
+      vitest: ^1.4.0
+    dependencies:
+      '@diet/theme': workspace:*
+      '@diet/ui': workspace:*
+      '@expo/next-adapter': ^5.0.0
+      framer-motion: ^11.0.0
+      next: 14.2.3
+      react: 18.2.0
+      react-dom: 18.2.0
+    devDependencies:
+      '@types/node': 20.11.24
+      '@types/react': 18.2.21
+      '@types/react-dom': 18.2.7
+      autoprefixer: ^10.4.16
+      eslint: ^8.56.0
+      eslint-config-next: 14.2.3
+      postcss: ^8.4.33
+      tailwindcss: ^3.4.3
+      typescript: ^5.3.3
+      vitest: ^1.4.0
+
+  packages/theme:
+    specifiers: {}
+    dependencies: {}
+    devDependencies: {}
+
+  packages/ui:
+    specifiers:
+      '@diet/theme': workspace:*
+      'expo-linear-gradient': ^12.7.2
+      'framer-motion': ^11.0.0
+    dependencies:
+      '@diet/theme': workspace:*
+      expo-linear-gradient: ^12.7.2
+      framer-motion: ^11.0.0
+
+packages: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ importers:
 
   apps/mobile:
     specifiers:
+      '@typescript-eslint/eslint-plugin': ^6.21.0
+      '@typescript-eslint/parser': ^6.21.0
       '@diet/theme': workspace:*
       '@diet/ui': workspace:*
       '@types/react': 18.2.21
@@ -22,6 +24,10 @@ importers:
       expo-linear-gradient: ^12.7.2
       expo-router: ~3.4.0
       eslint: ^8.56.0
+      eslint-config-prettier: ^9.1.0
+      eslint-plugin-react: ^7.34.1
+      eslint-plugin-react-hooks: ^4.6.0
+      eslint-plugin-react-native: ^4.0.0
       jest: ^29.7.0
       jest-expo: ^50.0.2
       nativewind: ^2.0.11
@@ -55,7 +61,13 @@ importers:
       '@types/react': 18.2.21
       '@types/react-native': 0.73.0
       '@types/react-test-renderer': 18.0.0
+      '@typescript-eslint/eslint-plugin': ^6.21.0
+      '@typescript-eslint/parser': ^6.21.0
       eslint: ^8.56.0
+      eslint-config-prettier: ^9.1.0
+      eslint-plugin-react: ^7.34.1
+      eslint-plugin-react-hooks: ^4.6.0
+      eslint-plugin-react-native: ^4.0.0
       jest: ^29.7.0
       jest-expo: ^50.0.2
       react-test-renderer: 18.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "moduleSuffixes": [".native", ".ios", ".android", ".web", ""]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": {
+      "cache": false,
+      "dependsOn": ["^dev"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "outputs": []
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "build/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- initialize a Turborepo workspace with Expo Router mobile and Next.js web apps plus shared theme/ui packages
- configure Tailwind to consume shared neon tokens and add a responsive AppShell with animated gradients
- wire CI to run pnpm lint/test/build and document mobile/web launch commands

## Testing
- not run (setup only)

------
https://chatgpt.com/codex/tasks/task_e_68ef5cc305f88322b001aaccb8a9fb25