### PR TITLE
Add ESLint config for web app and stabilize lint workflow

### DIFF
--- a/apps/mobile/.eslintrc.cjs
+++ b/apps/mobile/.eslintrc.cjs
@@ -21,7 +21,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
-    'plugin:react-native/recommended',
+    'plugin:react-native/all',
     'prettier',
   ],
   settings: {
@@ -35,5 +35,5 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },
-  ignorePatterns: ['node_modules/', 'dist/', 'build/'],
+  ignorePatterns: ['node_modules/', 'dist/', 'build/', 'tailwind.config.ts'],
 };

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,8 +4,26 @@
     "jsx": "preserve",
     "allowJs": true,
     "moduleResolution": "Bundler",
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "isolatedModules": true,
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../../packages/ui/src/**/*.ts", "../../packages/ui/src/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "../../packages/ui/src/**/*.ts",
+    "../../packages/ui/src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,10 @@
   },
   "dependencies": {
     "@diet/theme": "workspace:*",
-    "framer-motion": "^11.0.0",
-    "expo-linear-gradient": "^12.7.2"
+    "expo-linear-gradient": "^12.7.2",
+    "framer-motion": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.21"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,11 +119,14 @@ importers:
   packages/ui:
     specifiers:
       '@diet/theme': workspace:*
+      '@types/react': 18.2.21
       'expo-linear-gradient': ^12.7.2
       'framer-motion': ^11.0.0
     dependencies:
       '@diet/theme': workspace:*
       expo-linear-gradient: ^12.7.2
       framer-motion: ^11.0.0
+    devDependencies:
+      '@types/react': 18.2.21
 
 packages: {}


### PR DESCRIPTION
## Summary
- add a Next.js ESLint configuration so `next lint` can run non-interactively
- align the web TypeScript project settings with Next.js recommendations to avoid future tsconfig rewrites
- update supporting packages and configs so the monorepo lint pipeline completes without prompts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f783e1df688322aaf681b40edf3c92